### PR TITLE
Add ccda_alt_service_enable to have the CCDA allowed

### DIFF
--- a/pieces/portal_onsite_and_wordpress.sql
+++ b/pieces/portal_onsite_and_wordpress.sql
@@ -10,3 +10,4 @@ REPLACE INTO globals VALUES ('rest_portal_api', 0, '1');
 REPLACE INTO globals VALUES ('rest_portal_fhir_api', 0, '1');
 REPLACE INTO globals VALUES ('oauth_password_grant', 0, '3');
 REPLACE INTO globals VALUES ('rest_system_scopes_api', 0, '1');
+REPLACE INTO globals VALUES ('ccda_alt_service_enable', 0, '3');


### PR DESCRIPTION
Turn on the global's flag for the ccda service so it will turn on by default if the node service isn't running.