### PR TITLE
fix for 'six' demos that run 7.0.1 and 7.0.2: dev demo for ubuntu 24 has been redirected to 'eight' demos on wiki; all now good on the demo tetris front

### DIFF
--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -27,7 +27,7 @@ startDemoWrapper() {
     elif [ "$1" == "five" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "3"
     elif [ "$1" == "six" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "6"
+        startDemo "$1" "mysql-openemr" "/etc/php/8.1/apache2" "ubuntu" "22-04-18" "22.04-18" "/var/www/html" "6"
     elif [ "$1" == "three" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-20" "24.04-20" "/var/www/html" "2"
     elif [ "$1" == "two" ]; then

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -19,12 +19,12 @@ four_b	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	four.openemr.
 five	https://github.com/openemr/openemr.git	v7_0_3_4	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 7.0.3 Production Demo
 five_a	https://github.com/openemr/openemr.git	v7_0_3_4	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 7.0.3 Production Demo
 five_b	https://github.com/openemr/openemr.git	v7_0_3_4	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 7.0.3 Production Demo
-six	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	six.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Ubuntu 24.04 (with nodejs 22)
-six_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
-six_b	https://github.com/openemr/openemr.git	rel-701	0	0	1	0	0	0	1	six.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.1 Development Demo on Ubuntu 24.04 (with nodejs 22)
-six_c	https://github.com/openemr/openemr.git	rel-701	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.1 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
-six_d	https://github.com/openemr/openemr.git	rel-702	0	0	1	0	0	0	1	six.openemr.io/d	hey	branch	0	0	0	0	Public OpenEMR 7.0.2 Development Demo on Ubuntu 24.04 (with nodejs 22)
-six_e	https://github.com/openemr/openemr.git	rel-702	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/e	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.2 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
+six	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	six.openemr.io	hey	branch	0	2	0	0	NOT USED - PRIOR Public OpenEMR Development Demo on Ubuntu 22.04 (with nodejs 18)
+six_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	2	0	0	NOT USED - PRIOR Public OpenEMR Development Demo With Demo Data on Ubuntu 22.04 (with nodejs 18)
+six_b	https://github.com/openemr/openemr.git	rel-701	0	0	1	0	0	0	1	six.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.1 Development Demo on Ubuntu 22.04 (with nodejs 18)
+six_c	https://github.com/openemr/openemr.git	rel-701	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.1 Development Demo With Demo Data on Ubuntu 22.04 (with nodejs 18)
+six_d	https://github.com/openemr/openemr.git	rel-702	0	0	1	0	0	0	1	six.openemr.io/d	hey	branch	0	0	0	0	Public OpenEMR 7.0.2 Development Demo on Ubuntu 22.04 (with nodejs 18)
+six_e	https://github.com/openemr/openemr.git	rel-702	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/e	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.2 Development Demo With Demo Data on Ubuntu 22.04 (with nodejs 18)
 seven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	seven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.4)
 seven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
 seven_b	https://github.com/openemr/openemr.git	rel-703	0	0	0	0	0	0	1	seven.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.3 Development Demo on Alpine 3.22 (with PHP 8.4)


### PR DESCRIPTION
This prior change also impacted the 7.0.1 and 7.0.2 dev demos. So basically reverted the prior changes and directed the ubuntu 24.04 php 8.3 development demo to 'eight'. Now all good :)