### PR TITLE
feat(demo-build): drop privileges to the web user for OpenEMR CLI invocations

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -115,6 +115,15 @@ else
  htmlDirApache=false;
  alpineOs=false;
 fi
+# Web server user: alpine images use 'apache', Debian/Ubuntu uses 'www-data'.
+# Used when dropping privileges to run OpenEMR CLI scripts (RootCliGuard
+# in openemr#12267 refuses root). Mirrors the existing chown/chmod
+# branching elsewhere in this script.
+if $alpineOs; then
+ webUser=apache
+else
+ webUser=www-data
+fi
 LOG=$WEB/log/logSetup.txt
 mkdir -p $WEB/log
 CAPSULES=/home/openemr/capsules
@@ -543,21 +552,22 @@ IPADDRESS=$DOCKERDEMO
  sed -e 's@^exit;@ @' <$INST >$INSTTEMP
  DOCKERPARAMETERS="server=${DOCKERMYSQLHOST} loginhost=% login=${DOCKERDEMO} pass=${DOCKERDEMO} dbname=${DOCKERDEMO}"
  
+ # Drop privileges to the web user: RootCliGuard refuses root for the Installer class (openemr#12267).
  if $translationsDevelopment ; then
   echo "Using online development translation set"
   echo "Using online development translation set" >> $LOG
   if [ -z "$mrp" ] ; then
-   php -f $INSTTEMP development_translations=yes $DOCKERPARAMETERS >> $LOG
+   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP development_translations=yes $DOCKERPARAMETERS" >> $LOG
   else
-   php -f $INSTTEMP development_translations=yes rootpass=$mrp $DOCKERPARAMETERS >> $LOG
+   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP development_translations=yes rootpass=$mrp $DOCKERPARAMETERS" >> $LOG
   fi
  else
   echo "Using included translation set"
   echo "Using included translation set" >> $LOG
   if [ -z "$mrp" ] ; then
-   php -f $INSTTEMP $DOCKERPARAMETERS >> $LOG
+   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP $DOCKERPARAMETERS" >> $LOG
   else
-   php -f $INSTTEMP rootpass=$mrp $DOCKERPARAMETERS >> $LOG
+   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP rootpass=$mrp $DOCKERPARAMETERS" >> $LOG
   fi
  fi
  rm -f $INSTTEMP
@@ -570,7 +580,8 @@ IPADDRESS=$DOCKERDEMO
   echo "Upgrading via legacy patch" >> $LOG
   echo "<?php \$_GET['site'] = 'default'; ?>" > $OPENEMR/TEMPsql_patch.php
   cat $OPENEMR/sql_patch.php >> $OPENEMR/TEMPsql_patch.php
-  php -f $OPENEMR/TEMPsql_patch.php >> $LOG
+  # Drop privileges to the web user: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
+  su -p -s /bin/sh "$webUser" -c "php -f $OPENEMR/TEMPsql_patch.php" >> $LOG
   rm -f $OPENEMR/TEMPsql_patch.php
   echo "Completed upgrading via legacy patch"
   echo "Completed upgrading via legacy patch" >> $LOG
@@ -599,7 +610,8 @@ IPADDRESS=$DOCKERDEMO
    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php
    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${demoDataUpgradeFrom}';@" $OPENEMR/sql_upgrade_temp.php
    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" $OPENEMR/sql_upgrade_temp.php
-   php -f $OPENEMR/sql_upgrade_temp.php >> $LOG
+   # Drop privileges to the web user: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
+   su -p -s /bin/sh "$webUser" -c "php -f $OPENEMR/sql_upgrade_temp.php" >> $LOG
    rm -f $OPENEMR/sql_upgrade_temp.php
    # Also need to change encoding/collation when using OpenEMR versions at 6 or greater
    VERSION_MAJOR=$(collect_var \$v_major $OPENEMR/version.php)
@@ -661,7 +673,8 @@ IPADDRESS=$DOCKERDEMO
     sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php
     sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${demoDataUpgradeFrom}';@" $OPENEMR/sql_upgrade_temp.php
     sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" $OPENEMR/sql_upgrade_temp.php
-    php -f $OPENEMR/sql_upgrade_temp.php >> $LOG
+    # Drop privileges to the web user: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
+    su -p -s /bin/sh "$webUser" -c "php -f $OPENEMR/sql_upgrade_temp.php" >> $LOG
     rm -f $OPENEMR/sql_upgrade_temp.php
    fi
   else


### PR DESCRIPTION
  ## Summary                                                                                                                          
                                                                                                                                      
  openemr/openemr#12267 introduces a `RootCliGuard` that refuses to let OpenEMR CLI scripts run as root: anything that loads          
  `interface/globals.php`, runs through `bin/console`, or calls into the `Installer` class aborts with a `RuntimeException`. The
  failure it catches is the one that produced the original `/tmp/openemr-smarty` issue — PHP run as root creates files (cache dirs,   
  generated keys, Smarty compile output) the web server later cannot read, surfacing as opaque fatal errors deep in template rendering
   or OAuth.                                                                                                                          
                                                                                                                                      
  `demo_build.sh` runs several OpenEMR CLI scripts directly as root (the build user). Without this change, every demo build that hits
  the install / patch / upgrade paths would abort partway through.

  ## What changes                                                                                                                     
   
  Adds a `webUser` variable derived from the existing `alpineOs` flag (`apache` on Alpine, `www-data` on Debian/Ubuntu) and wraps     
  every OpenEMR CLI invocation in `su -p -s /bin/sh "$webUser" -c …`. `-p` preserves the env so `OPENEMR_ENABLE_INSTALLER_AUTO`,
  `PATH`, etc. propagate.
                                                                                                                                      
  Seven invocation sites wrapped, covering three distinct flows:
                                                                                                                                      
  | Flow | Site(s) | Underlying script |                          
  |---|---|---|                                                                                                                       
  | Initial install | 4 variants in the InstallerAuto block (different combinations of `translationsDevelopment` + `mrp` root-pass) |
  `contrib/util/installScripts/InstallerAuto.php` (`Installer` class) |                                                               
  | Legacy patch | 1 site | `sql_patch.php` |                     
  | Demo data + capsule upgrades | 2 sites | `sql_upgrade.php` |                                                                      
                                                                                                                                      
  ## Notes                                                                                                                            
                                                                                                                                      
  - Mirrors the chown/chmod branching already used elsewhere in the script (lines 469-476, 484, 647-655) — `$webUser` is just one more
   derivation off `$alpineOs`.            
  - Same shape as the privilege-drop pattern in the companion PRs (openemr/openemr#12267 and openemr/openemr-devops#743).             
  - No new dependencies; pure shell.                                                                                                  
                                              
  ## Related                                                                                                                          
                                                                                                                                      
  - **openemr/openemr#12267** — establishes the `RootCliGuard`. Required for this PR's wraps to be load-bearing rather than hygiene.  
  - **openemr/openemr-devops#743** — same `run_php_as_apache` pattern in the flex / 8.1.1 / binary docker images' devtools.           
                                                                                                                                      
  ## Test plan                                                                                                                        
   
  - [x] `bash -n demo_build.sh` syntax check passes.                                                                                  
  - [ ] Confirm a Debian/Ubuntu demo farm build end-to-end against an OpenEMR codebase containing #12267 — pending merges upstream.
  - [ ] Confirm an Alpine demo farm build end-to-end against the same — same gating.                                                  
                                                                  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
