### PR TITLE
chore(demo-farm): seed production demos for the 8.1 line

### DIFF
--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -18,9 +18,9 @@ three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	
 four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
 four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Beta With Demo Data
 four_b	https://github.com/rollingventures/openemr.git	bootstrap5-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/b	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Gamma With Demo Data
-five	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.0.0 Production Demo
-five_a	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.0.0 Production Demo
-five_b	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.0.0 Production Demo
+five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
+five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo
+five_b	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.1.0 Production Demo
 six	https://github.com/openemr/openemr.git	rel-704	0	1	0	0	0	0	1	six.openemr.io	hey	branch	0	2	0	0	Public OpenEMR 7.0.4 Development Demo on Ubuntu 24.04 (with nodejs 22)
 six_a	https://github.com/openemr/openemr.git	rel-704	0	1	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
 seven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	seven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.4)


### PR DESCRIPTION
## What

Repoint the three production-demo rows (`five`, `five_a`, `five_b`, all `branch_tag=tag`) in `ip_map_branch.txt` from `v8_0_0_3` to `v8_1_0`, and update their descriptions to 8.1.0.

## Why

`bump-tag.yml` (via `IpMapBumper`) only advances `tag` rows whose existing tag's `MAJOR.MINOR` equals the new tag's. The production rows are on `v8_0_0_3` (8.0), so when `v8_1_0` is cut the `openemr-tag` dispatch matches **zero** rows and the production demos silently stay on 8.0.0. This is the documented "unseeded new minor line" gap — the first release on the 8.1 line has to be seeded by hand. After this lands, future 8.1.x patch releases advance these rows automatically.

## Merge timing

Merge **after** the `v8_1_0` tag exists on `openemr/openemr` (i.e. after the conductor release PR merges). The demo-farm host's nightly reset checks out the pinned tag, so merging before the tag is published would point the production demos at a nonexistent ref until the tag lands.