### PR TITLE
fix(demo-farm): correct six cluster Ubuntu version to 24.04-22

### DIFF
--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -27,7 +27,7 @@ startDemoWrapper() {
     elif [ "$1" == "five" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php84" "alpine" "3-22" "3.22" "/var/www/localhost/htdocs" "3"
     elif [ "$1" == "six" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "22-04-22" "22.04-22" "/var/www/html" "2"
+        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
     elif [ "$1" == "three" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
     elif [ "$1" == "two" ]; then


### PR DESCRIPTION
## Summary
- `startDemoWrapper`'s `six` branch was passing `\"22-04-22\" \"22.04-22\"` (Ubuntu 22.04) to `startDemo`, but **`docker/php/22-04-22/` does not exist** in this repo — the cluster has been referencing a missing php.ini directory.
- `ip_map_branch.txt` rows for `six` / `six_a` describe the cluster as "Ubuntu 24.04 (with nodejs 22)", and the [OpenEMR 7.0.4 Development Demo wiki page](https://www.open-emr.org/wiki/index.php/Development_7.0.4_Demo) also describes `six.openemr.io` as Ubuntu 24.04 / PHP 8.3.
- `docker/php/24-04-22/php.ini` does exist. Switching the args to `"24-04-22" "24.04-22"` aligns the code with the rest of the configuration and the actual file layout.

## Side effect (out of scope here)
After this change, `six`'s `startDemo` args are identical to `three`'s (both Ubuntu 24.04-22 / PHP 8.3 / 2 instances). That's a smell for future cluster consolidation but not addressed in this PR.

## Test plan
- [x] Diff confirms exactly one line changed (`docker/scripts/demoLibrary.source:30`).
- [x] `docker/php/24-04-22/` exists in the tree.
- [ ] Confirm `six` cluster starts cleanly with the new args on next farm reset.

Assisted-by: Claude Code