### PR TITLE
chore(demo-farm): retire 7.0.1/7.0.2/7.0.3 demos and 'nine' ajax cruft

### DIFF
--- a/docker/html/admin/ajax_admin_demo_farm.php
+++ b/docker/html/admin/ajax_admin_demo_farm.php
@@ -51,9 +51,6 @@ if (!empty($_POST['procedure'])) {
         case 'status_eight_openemr':
             collectProcedure('docker logs eight-openemr', $output);
             break;
-        case 'status_nine_openemr':
-            collectProcedure('docker logs nine-openemr', $output);
-            break;
         case 'status_ten_openemr':
             collectProcedure('docker logs ten-openemr', $output);
             break;
@@ -90,12 +87,6 @@ if (!empty($_POST['procedure'])) {
         case 'refresh_one_c_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one c', $output);
             break;
-        case 'refresh_one_d_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one d', $output);
-            break;
-        case 'refresh_one_e_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one e', $output);
-            break;
         case 'refresh_one_f_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one f', $output);
             break;
@@ -116,12 +107,6 @@ if (!empty($_POST['procedure'])) {
             break;
         case 'refresh_two_c_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two c', $output);
-            break;
-        case 'refresh_two_d_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two d', $output);
-            break;
-        case 'refresh_two_e_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two e', $output);
             break;
         case 'restart_three_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh three', $output);
@@ -203,12 +188,6 @@ if (!empty($_POST['procedure'])) {
             break;
         case 'refresh_ten_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh ten a', $output);
-            break;
-        case 'refresh_ten_b_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh ten b', $output);
-            break;
-        case 'refresh_ten_c_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh ten c', $output);
             break;
         case 'restart_eleven_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven', $output);

--- a/docker/html/admin/index.php
+++ b/docker/html/admin/index.php
@@ -221,8 +221,6 @@
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One A Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One B Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One C Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_d_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One D Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_e_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One E Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_f_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One F Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_g_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One G Refresh</button>
                                                     </div>
@@ -249,8 +247,6 @@
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two A Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two B Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two C Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_d_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two D Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_e_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two E Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -411,8 +407,6 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_ten_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Ten Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_ten_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Ten A Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_ten_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Ten B Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_ten_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Ten C Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -19,7 +19,7 @@ startDemoWrapper() {
     elif [ "$1" == "eight" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
     elif [ "$1" == "ten" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php81" "alpine" "3-17" "3.17" "/var/www/localhost/htdocs" "4"
+        startDemo "$1" "mysql-openemr" "/etc/php81" "alpine" "3-17" "3.17" "/var/www/localhost/htdocs" "2"
     elif [ "$1" == "eleven" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "4"
     elif [ "$1" == "four" ]; then
@@ -31,9 +31,9 @@ startDemoWrapper() {
     elif [ "$1" == "three" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
     elif [ "$1" == "two" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php82" "alpine" "3-18" "3.18" "/var/www/localhost/htdocs" "6"
+        startDemo "$1" "mysql-openemr" "/etc/php82" "alpine" "3-18" "3.18" "/var/www/localhost/htdocs" "4"
     elif [ "$1" == "one" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "8"
+        startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "6"
     elif [ "$1" == "edu" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php82" "alpine" "3-18" "3.18" "/var/www/localhost/htdocs" "2"
     else

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -3,16 +3,12 @@ one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	h
 one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
 one_b	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	0	0	1	one.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.20 (with PHP 8.3)
 one_c	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
-one_d	https://github.com/openemr/openemr.git	rel-703	0	0	0	0	0	0	1	one.openemr.io/d	hey	branch	0	0	0	0	Public OpenEMR 7.0.3 Development Demo on Alpine 3.20 (with PHP 8.3)
-one_e	https://github.com/openemr/openemr.git	rel-703	0	0	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/e	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.3 Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
 one_f	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	one.openemr.io/f	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.20 (with PHP 8.3)
 one_g	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/g	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
 two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.18 (with PHP 8.2)
 two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
 two_b	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	two.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.18 (with PHP 8.2)
 two_c	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
-two_d	https://github.com/openemr/openemr.git	rel-702	0	0	0	0	0	0	1	two.openemr.io/d	hey	branch	0	0	0	0	Public OpenEMR 7.0.2 Development Demo on Alpine 3.18 (with PHP 8.2)
-two_e	https://github.com/openemr/openemr.git	rel-702	0	0	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/e	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.2 Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
 three	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Ubuntu 24.04 (with nodejs 22)
 three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
 four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
@@ -33,8 +29,6 @@ eight	https://github.com/openemr/openemr.git	master	0	1	1	0	0	0	1	eight.openemr.
 eight_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
 ten	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	ten.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.17
 ten_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo on Alpine 3.17 With Demo Data
-ten_b	https://github.com/openemr/openemr.git	rel-701	0	0	0	0	0	0	1	ten.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.1 Development Demo on Alpine 3.17
-ten_c	https://github.com/openemr/openemr.git	rel-701	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.1 Development Demo on Alpine 3.17 With Demo Data
 eleven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	eleven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.5)
 eleven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 eleven_b	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eleven.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)


### PR DESCRIPTION
## Summary
Follows the wiki retirement of [Development_7.0.1_Demo](https://www.open-emr.org/wiki/index.php/Development_7.0.1_Demo), [Development_7.0.2_Demo](https://www.open-emr.org/wiki/index.php/Development_7.0.2_Demo), and [Development_7.0.3_Demo](https://www.open-emr.org/wiki/index.php/Development_7.0.3_Demo) (each now bears a "this demo has been shut-down" notice). Brings the source surfaces in line with the live wiki state.

## Changes
- **`ip_map_branch.txt`**: drop 6 rows for the retired instances —
  - `one_d`, `one_e` (7.0.3 on Alpine 3.20)
  - `two_d`, `two_e` (7.0.2 on Alpine 3.18)
  - `ten_b`, `ten_c` (7.0.1 on Alpine 3.17)
- **`docker/scripts/demoLibrary.source`**: `startDemoWrapper` instance counts updated —
  - `one`: 8 → 6
  - `two`: 6 → 4
  - `ten`: 4 → 2
- **`docker/html/admin/index.php`**: remove the 6 corresponding `refresh_*` buttons.
- **`docker/html/admin/ajax_admin_demo_farm.php`**: remove the 6 corresponding `refresh_*` case branches **+** sweep the long-stale `case 'status_nine_openemr':` (cluster `nine` had been retired previously but the ajax dispatcher entry persisted).

## Diffstat
4 files changed, +3 / −36

## Behavior
No change for surviving clusters/instances — this is a config-and-UI sync to match the current wiki state. Surviving cluster shapes:
- `one` (Alpine 3.20 / PHP 8.3): 6 instances (master, 7.0.4, 8.0.0)
- `two` (Alpine 3.18 / PHP 8.2): 4 instances (master, 8.0.0)
- `ten` (Alpine 3.17 / PHP 8.1): 2 instances (master only)

## Test plan
- [x] No remaining grep hits for retired instance ids across `*.php`, `*.sh`, `*.source`, `*.txt`.
- [x] `bash -n docker/scripts/demoLibrary.source` syntax-clean.
- [ ] Next farm reset cycles `one`/`two`/`ten` cleanly with the new instance counts (8/4/2 → 6/4/2).

Assisted-by: Claude Code