### PR TITLE
chore(demo-farm): bookmark/retire wiki-orphaned demos + consolidate bookmark clusters on Alpine 3.23

### DIFF
--- a/docker/html/admin/ajax_admin_demo_farm.php
+++ b/docker/html/admin/ajax_admin_demo_farm.php
@@ -81,18 +81,6 @@ if (!empty($_POST['procedure'])) {
         case 'refresh_one_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one a', $output);
             break;
-        case 'refresh_one_b_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one b', $output);
-            break;
-        case 'refresh_one_c_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one c', $output);
-            break;
-        case 'refresh_one_f_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one f', $output);
-            break;
-        case 'refresh_one_g_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one g', $output);
-            break;
         case 'restart_two_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two', $output);
             break;
@@ -101,12 +89,6 @@ if (!empty($_POST['procedure'])) {
             break;
         case 'refresh_two_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two a', $output);
-            break;
-        case 'refresh_two_b_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two b', $output);
-            break;
-        case 'refresh_two_c_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh two c', $output);
             break;
         case 'restart_three_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh three', $output);

--- a/docker/html/admin/index.php
+++ b/docker/html/admin/index.php
@@ -219,10 +219,6 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One A Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One B Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One C Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_f_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One F Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_one_g_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">One G Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -245,8 +241,6 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two A Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two B Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_two_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Two C Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -17,9 +17,9 @@ startDemoWrapper() {
     if [ "$1" == "seven" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php84" "alpine" "3-22" "3.22" "/var/www/localhost/htdocs" "6"
     elif [ "$1" == "eight" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
+        startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "2"
     elif [ "$1" == "ten" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php81" "alpine" "3-17" "3.17" "/var/www/localhost/htdocs" "2"
+        startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "2"
     elif [ "$1" == "eleven" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "4"
     elif [ "$1" == "four" ]; then
@@ -27,15 +27,15 @@ startDemoWrapper() {
     elif [ "$1" == "five" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php84" "alpine" "3-22" "3.22" "/var/www/localhost/htdocs" "3"
     elif [ "$1" == "six" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
+        startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "2"
     elif [ "$1" == "three" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php/8.3/apache2" "ubuntu" "24-04-22" "24.04-22" "/var/www/html" "2"
+        startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "2"
     elif [ "$1" == "two" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php82" "alpine" "3-18" "3.18" "/var/www/localhost/htdocs" "4"
-    elif [ "$1" == "one" ]; then
-        startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "6"
-    elif [ "$1" == "edu" ]; then
         startDemo "$1" "mysql-openemr" "/etc/php82" "alpine" "3-18" "3.18" "/var/www/localhost/htdocs" "2"
+    elif [ "$1" == "one" ]; then
+        startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "2"
+    elif [ "$1" == "edu" ]; then
+        startDemo "$1" "mysql-openemr" "/etc/php85" "alpine" "3-23" "3.23" "/var/www/localhost/htdocs" "2"
     else
         startDemo "$1" "mysql-openemr" "/etc/php83" "alpine" "3-20" "3.20" "/var/www/localhost/htdocs" "1"
     fi

--- a/docker/scripts/restartFarm.sh
+++ b/docker/scripts/restartFarm.sh
@@ -8,23 +8,11 @@
 # (at your option) any later version.
 #
 
-# Always check for a new versions of the custom docker images
-# NOTE 14.04 does not work with development OpenEMR since php version is too low,
-#      but collecting it in case somebody wishes to make it work with older
-#      OpenEMR versions.
-docker pull openemr/pre-openemr:22.04-18
-docker pull openemr/pre-openemr:24.04-20
-docker pull openemr/pre-openemr:24.04-22
-docker pull openemr/pre-openemr:3.15-8
-docker pull openemr/pre-openemr:3.16
-docker pull openemr/pre-openemr:3.17
+# Always check for new versions of the custom docker images
 docker pull openemr/pre-openemr:3.18
-docker pull openemr/pre-openemr:3.19
 docker pull openemr/pre-openemr:3.20
-docker pull openemr/pre-openemr:3.21
 docker pull openemr/pre-openemr:3.22
-docker pull openemr/pre-openemr:edge
-docker pull openemr/php-ssh:7.1-fpm-alpine
+docker pull openemr/pre-openemr:3.23
 
 # update demo_farm_openemr repo
 cd ~/demo_farm_openemr
@@ -51,10 +39,10 @@ cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/trans
 
 # restart openemr demo docker containers
 # (note do not restart nginx, php, mysql, and phpmyadmin dockers)
-# (also note doing the demo 'four' at end to be more efficient since it will set up 10 subdemos)
+# (also note doing the demo 'four' at end to be more efficient since it will set up 3 subdemos)
 # (also note demo 'five' is at beginning since this is the "main" demos)
 # (also note that demo 'edu' are just refreshing subdemos to allow persistent demos that
-#  do not reset; for example `edu empty` and `edu c` subdemos are not being reset)
+#  do not reset; for example `edu empty` subdemo is not being reset)
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh five
 sleep 30m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -38,55 +38,25 @@
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 # for building pre-openemr with the Dockerfiles (cd to path with the Dockerfile)
-#cd ~/demo_farm_openemr/docker/pre-openemr/22-04-18/
-#docker build -t openemr/pre-openemr:22.04-18 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/24-04-20/
-#docker build -t openemr/pre-openemr:24.04-20 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/24-04-22/
-#docker build -t openemr/pre-openemr:24.04-22 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/3-15-8/
-#docker build -t openemr/pre-openemr:3.15-8 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/3-16/
-#docker build -t openemr/pre-openemr:3.16 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/3-17/
-#docker build -t openemr/pre-openemr:3.17 .
 #cd ~/demo_farm_openemr/docker/pre-openemr/3-18/
 #docker build -t openemr/pre-openemr:3.18 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/3-19/
-#docker build -t openemr/pre-openemr:3.19 .
 #cd ~/demo_farm_openemr/docker/pre-openemr/3-20/
 #docker build -t openemr/pre-openemr:3.20 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/3-21/
-#docker build -t openemr/pre-openemr:3.21 .
 #cd ~/demo_farm_openemr/docker/pre-openemr/3-22/
 #docker build -t openemr/pre-openemr:3.22 .
-#cd ~/demo_farm_openemr/docker/pre-openemr/edge/
-#docker build -t openemr/pre-openemr:edge .
-#cd ~/demo_farm_openemr/docker/php-ssh/
-#docker build -t openemr/php-ssh:7.1-fpm-alpine .
+#cd ~/demo_farm_openemr/docker/pre-openemr/3-23/
+#docker build -t openemr/pre-openemr:3.23 .
 
 # to collect the standard docker images
 docker pull nginx
 docker pull mariadb:10.6
 docker pull phpmyadmin/phpmyadmin
 
-# Always check for a new versions of the custom docker images
-# NOTE 14.04 does not work with development OpenEMR since php version is too low,
-#      but collecting it in case somebody wishes to make it work with older
-#      OpenEMR versions.
-docker pull openemr/pre-openemr:22.04-18
-docker pull openemr/pre-openemr:24.04-20
-docker pull openemr/pre-openemr:24.04-22
-docker pull openemr/pre-openemr:3.15-8
-docker pull openemr/pre-openemr:3.16
-docker pull openemr/pre-openemr:3.17
+# Always check for new versions of the custom docker images
 docker pull openemr/pre-openemr:3.18
-docker pull openemr/pre-openemr:3.19
 docker pull openemr/pre-openemr:3.20
-docker pull openemr/pre-openemr:3.21
 docker pull openemr/pre-openemr:3.22
-docker pull openemr/pre-openemr:edge
-docker pull openemr/php-ssh:7.1-fpm-alpine
+docker pull openemr/pre-openemr:3.23
 
 # to start network
 docker network create mynet
@@ -114,7 +84,7 @@ cp -r ~/demo_farm_openemr/docker/html/* ~/html/
 cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/translations/
 
 # bring in the dockers (note reverse-proxy needs to be done last)
-# (also note doing the demo 'four' at end to be more efficient since it will set up 10 subdemos)
+# (also note doing the demo 'four' at end to be more efficient since it will set up 3 subdemos)
 # (also note demo 'five' is at beginning since this is the "main" demos)
 # (also note placed the `edu` demos docker at the end)
 startMysql

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,37 +1,31 @@
 docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching	demo_data	demo_ssh	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
 one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.20 (with PHP 8.3)
 one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
-one_b	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	0	0	1	one.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.20 (with PHP 8.3)
-one_c	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
-one_f	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	one.openemr.io/f	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.20 (with PHP 8.3)
-one_g	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/g	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.20 (with PHP 8.3)
 two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.18 (with PHP 8.2)
 two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
-two_b	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	two.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.18 (with PHP 8.2)
-two_c	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
-three	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Ubuntu 24.04 (with nodejs 22)
-three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
+three	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	[bookmark]
+three_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
 four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Beta With Demo Data
 four_b	https://github.com/rollingventures/openemr.git	bootstrap5-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/b	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Gamma With Demo Data
 five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
 five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo
 five_b	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.1.0 Production Demo
-six	https://github.com/openemr/openemr.git	rel-704	0	1	0	0	0	0	1	six.openemr.io	hey	branch	0	2	0	0	Public OpenEMR 7.0.4 Development Demo on Ubuntu 24.04 (with nodejs 22)
-six_a	https://github.com/openemr/openemr.git	rel-704	0	1	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
+six	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	six.openemr.io	hey	branch	0	0	0	0	[bookmark]
+six_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 seven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	seven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.4)
 seven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
 seven_b	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	seven.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.22 (with PHP 8.4)
 seven_c	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
 seven_d	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	seven.openemr.io/d	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.22 (with PHP 8.4)
 seven_e	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/e	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
-eight	https://github.com/openemr/openemr.git	master	0	1	1	0	0	0	1	eight.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Ubuntu 24.04 (with nodejs 22)
-eight_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Ubuntu 24.04 (with nodejs 22)
-ten	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	ten.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.17
-ten_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo on Alpine 3.17 With Demo Data
+eight	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	[bookmark]
+eight_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
+ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[bookmark]
+ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 eleven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	eleven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.5)
 eleven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 eleven_b	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eleven.openemr.io/b	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
 eleven_c	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/c	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
-edu	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.18 (with PHP 8.2)
-edu_a	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data on Alpine 3.18 (with PHP 8.2)
+edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[bookmark]
+edu_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]


### PR DESCRIPTION
## Summary
Follows the latest wiki cleanup ([Development_Demo](https://www.open-emr.org/wiki/index.php/Development_Demo), [8.0.0](https://www.open-emr.org/wiki/index.php/Development_8.0.0_Demo), [7.0.4](https://www.open-emr.org/wiki/index.php/Development_7.0.4_Demo) pages now only reference the surviving distro coverage). Reconciles \`ip_map_branch.txt\` + admin UI to match, consolidates the now-bookmarked clusters onto Alpine 3.23 / PHP 8.5, and sweeps the queued farm-script drift items.

## Wiki sync — bookmark vs. retire

**Bookmark when can't remove** (first 2 slots of an all-orphaned cluster, or between real entries): mark as master with description \`[bookmark]\` and zero out \`use_development_translations\`, \`serve_packages\`, and \`fun_stuff\`. **10 rows kept as bookmarks** across 5 all-orphaned clusters: \`three\`/\`_a\`, \`six\`/\`_a\`, \`edu\`/\`_a\`, \`eight\`/\`_a\`, \`ten\`/\`_a\`.

**Retire when at end of cluster**: drop the row entirely. **6 rows retired** — \`one_b\`/\`_c\`/\`_f\`/\`_g\` (after the \`one_a\` master pair), \`two_b\`/\`_c\` (after the \`two_a\` master pair).

Cluster count: 11 (unchanged). Row count: 42 → 36 (PR #113) → 30.

Cascading edits for the retirements:
- \`startDemoWrapper\` instance counts: \`one\` 6→2, \`two\` 4→2.
- \`admin/index.php\`: dropped 6 refresh buttons.
- \`admin/ajax_admin_demo_farm.php\`: dropped 6 corresponding cases.

## Consolidate bookmark clusters on Alpine 3.23 / PHP 8.5

All 5 fully-bookmarked clusters re-pointed in \`startDemoWrapper\` to \`alpine 3-23 / 3.23 / /etc/php85\` (matching \`eleven\`'s config):

| Cluster | Was | Now |
|---|---|---|
| \`three\` + \`_a\` | Ubuntu 24.04 / PHP 8.3 | Alpine 3.23 / PHP 8.5 |
| \`six\` + \`_a\` | Ubuntu 24.04 / PHP 8.3 | Alpine 3.23 / PHP 8.5 |
| \`eight\` + \`_a\` | Ubuntu 24.04 / PHP 8.3 | Alpine 3.23 / PHP 8.5 |
| \`ten\` + \`_a\` | Alpine 3.17 / PHP 8.1 (EOL) | Alpine 3.23 / PHP 8.5 |
| \`edu\` + \`_a\` | Alpine 3.18 / PHP 8.2 | Alpine 3.23 / PHP 8.5 |

This eliminates Ubuntu and Alpine 3.17 from the active distro set entirely. **Distros still in use after this PR**: Alpine 3.18 (\`two\`), 3.20 (\`one\`), 3.22 (\`four\`/\`five\`/\`seven\`), 3.23 (\`eleven\` + the 5 bookmark clusters).

Bookmark cluster URLs (e.g., \`six.openemr.io/a\`) keep working — they now serve master on Alpine 3.23 / PHP 8.5 instead of their prior release-pinned configs on older distros.

## Farm-script drift sweep (bundled)

\`startFarm.sh\` and \`restartFarm.sh\`:
- Drop **10 unused** \`docker pull openemr/pre-openemr:*\` lines: \`22.04-18\`, \`24.04-20\`, \`24.04-22\`, \`3.15-8\`, \`3.16\`, \`3.17\`, \`3.19\`, \`3.21\`, \`edge\`, plus the ancient \`openemr/php-ssh:7.1-fpm-alpine\`. (\`24.04-22\` and \`3.17\` became unused via the consolidation above; the rest were pre-existing drift.)
- Add \`docker pull openemr/pre-openemr:3.23\` for consistency.
- Drop the stale "14.04 does not work" comment block.

\`startFarm.sh\`: pare the commented-out \`docker build\` block to currently-used tags only (\`3-18\`, \`3-20\`, \`3-22\`, \`3-23\`).

Both files: fix "10 subdemos" comment for cluster \`four\` — it has 3 subdemos now.

\`restartFarm.sh\`: fix the \`edu c\` stale comment.

## Diffstat
6 files changed, +26 / −98.

## Test plan
- [x] \`bash -n\` syntax-clean on both farm scripts and \`demoLibrary.source\`.
- [x] No remaining grep hits for retired instance IDs (\`one_b\`/\`_c\`/\`_f\`/\`_g\`, \`two_b\`/\`_c\`) across PHP, source, sh, conf, txt files.
- [x] Per-cluster row counts in \`ip_map_branch.txt\` align with \`startDemoWrapper\` instance counts (\`one\`=2, \`two\`=2; bookmark clusters \`three\`/\`six\`/\`eight\`/\`ten\`/\`edu\`=2; others unchanged).
- [x] All 5 bookmark clusters now resolve to Alpine 3.23 / PHP 8.5 in \`startDemoWrapper\`.
- [x] Pull list contains only the 4 distro tags actually referenced (\`3.18\`, \`3.20\`, \`3.22\`, \`3.23\`).
- [ ] Verify next farm reset cycles bookmarked clusters cleanly on the new Alpine 3.23 / PHP 8.5 base.

## Follow-up
Crud cleanup of unused \`docker/pre-openemr/\`, \`docker/php/\`, \`docker/postfix/\` subdirectories (the actual Dockerfiles and \`php.ini\` files for the retired distros) will land in a separate PR after this one merges.

Assisted-by: Claude Code