### PR TITLE
chore(demo-farm): drop DEPRECATED rows, strip FUTURE prefixes

### DIFF
--- a/docker/html/admin/ajax_admin_demo_farm.php
+++ b/docker/html/admin/ajax_admin_demo_farm.php
@@ -141,18 +141,6 @@ if (!empty($_POST['procedure'])) {
         case 'refresh_seven_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven a', $output);
             break;
-        case 'refresh_seven_b_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven b', $output);
-            break;
-        case 'refresh_seven_c_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven c', $output);
-            break;
-        case 'refresh_seven_d_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven d', $output);
-            break;
-        case 'refresh_seven_e_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven e', $output);
-            break;
         case 'restart_eight_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eight', $output);
             break;
@@ -179,12 +167,6 @@ if (!empty($_POST['procedure'])) {
             break;
         case 'refresh_eleven_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven a', $output);
-            break;
-        case 'refresh_eleven_b_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven b', $output);
-            break;
-        case 'refresh_eleven_c_openemr':
-            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven c', $output);
             break;
         case 'restart_edu_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh edu', $output);

--- a/docker/html/admin/index.php
+++ b/docker/html/admin/index.php
@@ -353,10 +353,6 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven A Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven B Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven C Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_d_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven D Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_seven_e_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Seven E Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>
@@ -423,8 +419,6 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_eleven_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eleven Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_eleven_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eleven A Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_eleven_b_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eleven B Refresh</button>
-                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_eleven_c_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eleven C Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -63,7 +63,7 @@ startDemoWrapper() {
             ;;
         seven)
             image="${FLEX_IMAGE_3_23_PHP_8_4}"
-            count=6
+            count=2
             ;;
         eight)
             # FUTURE: 8.1.0 release demo (rel-810)
@@ -77,7 +77,7 @@ startDemoWrapper() {
             ;;
         eleven)
             image="${FLEX_IMAGE_3_23_PHP_8_5}"
-            count=4
+            count=2
             ;;
         edu)
             # bookmark cluster

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -3,29 +3,23 @@ one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	h
 one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.3)
 two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.2)
 two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Alpine 3.22 (with PHP 8.2)
-three	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	FUTURE Public OpenEMR 8.0.0 Development Demo on Alpine 3.22 (with PHP 8.4)
-three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	FUTURE Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
+three	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.22 (with PHP 8.4)
+three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
 four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
 four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Beta With Demo Data
 four_b	https://github.com/rollingventures/openemr.git	bootstrap5-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/b	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Gamma With Demo Data
 five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
 five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo
 five_b	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.1.0 Production Demo
-six	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	six.openemr.io	hey	branch	0	0	0	0	FUTURE Public OpenEMR 7.0.4 Development Demo on Alpine 3.22 (with PHP 8.4)
-six_a	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	0	0	0	FUTURE Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
+six	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	six.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.22 (with PHP 8.4)
+six_a	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
 seven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	seven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.4)
 seven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.4)
-seven_b	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	seven.openemr.io/b	hey	branch	0	0	0	0	DEPRECATED Public OpenEMR 8.0.0 Development Demo on Alpine 3.23 (with PHP 8.4)
-seven_c	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/c	hey	branch	5.0.0	0	0	0	DEPRECATED Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.4)
-seven_d	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	seven.openemr.io/d	hey	branch	0	0	0	0	DEPRECATED Public OpenEMR 7.0.4 Development Demo on Alpine 3.23 (with PHP 8.4)
-seven_e	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/e	hey	branch	5.0.0	0	0	0	DEPRECATED Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.4)
-eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	FUTURE Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
-eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	FUTURE Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
+eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
+eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[bookmark]
 ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 eleven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	eleven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.5)
 eleven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
-eleven_b	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eleven.openemr.io/b	hey	branch	0	0	0	0	DEPRECATED Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
-eleven_c	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/c	hey	branch	5.0.0	0	0	0	DEPRECATED Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[bookmark]
 edu_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]


### PR DESCRIPTION
## Summary

Follow-up cleanup to #116 (the flex pivot, which also split master vs. release-branch demos across separate clusters). The transitional `DEPRECATED ` / `FUTURE ` markers introduced in #116 can now go away, because the corresponding wiki migration is complete.

### Wiki migration audit (just verified)

- `Development_Demo` wiki page (8.0.0) -> points at `three.openemr.io[/a]`
- `Development_7.0.4_Demo` wiki page -> points at `six.openemr.io[/a]`
- `Development_8.1.0_Demo` wiki page (new) -> points at `eight.openemr.io[/a]`
- Zero residual references to `seven.openemr.io/b|c|d|e` or `eleven.openemr.io/b|c` anywhere on the wiki or open-emr.org/demo/.

So the release-branch demos now live exclusively on their own clusters; the temporary copies on seven/eleven can be retired and the FUTURE flags can come off.

## Changes

- **`ip_map_branch.txt`**: dropped 6 rows (`seven_b`, `seven_c`, `seven_d`, `seven_e`, `eleven_b`, `eleven_c`). Stripped the leading `FUTURE ` from the description column on 6 rows (`three`, `three_a`, `six`, `six_a`, `eight`, `eight_a`) since those are now the live release demos, not transitional.
- **`docker/scripts/demoLibrary.source`** (`startDemoWrapper`): `seven` instance count `6 -> 2`, `eleven` instance count `4 -> 2`. Both clusters now only host `master` + `master_a`.
- **`docker/html/admin/index.php`**: removed 6 refresh buttons (`refresh_seven_b/c/d/e_openemr`, `refresh_eleven_b/c_openemr`).
- **`docker/html/admin/ajax_admin_demo_farm.php`**: removed the 6 corresponding ajax cases.

Net diff: 4 files, +8/-38.

## Cluster shape after this PR

| cluster | rows | role |
|---|---|---|
| one | 2 | master demo (Alpine 3.23 / PHP 8.3) |
| two | 2 | master demo (Alpine 3.22 / PHP 8.2) |
| three | 2 | **8.0.0 release demo (rel-800)** |
| four | 3 | UFG demos |
| five | 3 | production demo (v8_1_0) |
| six | 2 | **7.0.4 release demo (rel-704)** |
| seven | 2 | master demo (Alpine 3.23 / PHP 8.4) |
| eight | 2 | **8.1.0 release demo (rel-810)** |
| ten | 2 | bookmark cluster |
| eleven | 2 | master demo (Alpine 3.23 / PHP 8.5) |
| edu | 2 | bookmark cluster |

Every cluster except production (`five`) and UFG (`four`) now has exactly 2 instances. Master demos and release-pinned demos are cleanly separated -- adding a new release in the future is just "pick a bookmark cluster (`ten` or `edu`), point it at the new `rel-X` branch."

## Test plan

- [x] `grep -rnE 'seven_[bcde]|eleven_[bc]'` returns zero hits across `*.php`, `*.sh`, `*.source`, `*.txt`, `*.conf`.
- [x] `bash -n docker/scripts/demoLibrary.source` passes.
- [x] `ip_map_branch.txt` has 24 data rows (was 30; -6 DEPRECATED rows).
- [x] Cluster-row tally matches expected shape (table above).
- [x] No `FUTURE` or `DEPRECATED` tokens remain in `ip_map_branch.txt`.
- [ ] Post-merge: on next farm refresh, the 6 retired containers stop being respawned; admin page no longer shows the 6 refresh buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)