### PR TITLE
fix(demo-farm): set patient portal + API globals when patient_portals_and_api=1

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -291,11 +291,11 @@ IPADDRESS=$DOCKERDEMO
  echo "$ds"
  echo -n "ds option is " >> $LOG
  echo "$ds" >> $LOG
- wp=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 10`
- echo -n "wp option is "
- echo "$wp"
- echo -n "wp option is " >> $LOG
- echo "$wp" >> $LOG
+ ppapi=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 10`
+ echo -n "ppapi option is "
+ echo "$ppapi"
+ echo -n "ppapi option is " >> $LOG
+ echo "$ppapi" >> $LOG
  EXTERNALLINK=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 11`
  echo -n "external link is "
  echo "$EXTERNALLINK"
@@ -669,6 +669,22 @@ IPADDRESS=$DOCKERDEMO
   echo "$RANDOM_THEME" >> $LOG
   #set the random theme
   mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e "UPDATE ${DOCKERDEMO}.globals SET gl_value='${RANDOM_THEME}' WHERE gl_name='css_header'"
+ fi
+
+ # Enable patient portal + REST/FHIR/OAuth APIs for demos with the
+ # patient_portals_and_api flag set in ip_map_branch.txt.
+ if [ "$ppapi" = "1" ]; then
+  echo "Setting up patient portal and API globals"
+  echo "Setting up patient portal and API globals" >> $LOG
+  mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e "
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='portal_onsite_two_enable';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_api';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_fhir_api';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_portal_api';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='3' WHERE gl_name='oauth_password_grant';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_system_scopes_api';
+    UPDATE ${DOCKERDEMO}.globals SET gl_value='3' WHERE gl_name='ccda_alt_service_enable';
+  "
  fi
 
  #reinstitute file permissions


### PR DESCRIPTION
## Summary
OAuth-protected API access on the demos has been silently failing — the OpenEMR OAuth listener (`src/RestControllers/Subscriber/OAuth2AuthorizationListener.php:102`) invalidates the session when `rest_api`, `rest_fhir_api`, and `rest_portal_api` are all empty, and right now those globals aren't being set on any demo.

This PR restores the API enablement via direct `mariadb UPDATE`s in `demo_build.sh`, in the same style as the existing `site_addr_oath` and `css_header` mutations. Gated on the `patient_portals_and_api` flag (column 10 of `ip_map_branch.txt`), which is currently `1` for every cluster.

## Globals set when the flag is `1`

| Global | Value | Purpose |
|---|---|---|
| `portal_onsite_two_enable` | `'1'` | Enable Patient Portal v2 |
| `rest_api` | `'1'` | REST API |
| `rest_fhir_api` | `'1'` | FHIR REST API |
| `rest_portal_api` | `'1'` | Patient Portal REST API |
| `oauth_password_grant` | `'3'` | OAuth password grant |
| `rest_system_scopes_api` | `'1'` | REST system scopes |
| `ccda_alt_service_enable` | `'3'` | C-CDA service |

All seven are defined in OpenEMR's current `library/globals.inc.php` — either as direct keys (`portal_onsite_two_enable`, `ccda_alt_service_enable`) or via the `GlobalConnectorsEnum` indirection used in the Connectors tab section (lines 3267+). Because the globals are recognized by OpenEMR's installer, rows already exist in the `globals` table, so `UPDATE … WHERE gl_name='X'` hits them. (`REPLACE INTO` would also work but `UPDATE` matches the existing pattern and is safer if OpenEMR ever drops one of these globals.)

## Variable rename: `wp` → `ppapi`

The local variable that holds column 10 has been read as `wp` (a vestige of when this column controlled WordPress demo enablement). Renaming to `ppapi` so the new conditional block at the use site reads sensibly. 5 occurrences in the variable-read block, ~3-line conditional in the new block.

## Diffstat
1 file changed, 21 insertions, 5 deletions.

## Test plan
- [x] `bash -n demo_build.sh` — passes.
- [x] No remaining references to the old `wp` variable name.
- [x] New conditional uses `[ "$ppapi" = "1" ]` matching the existing column-value convention.
- [ ] After landing: verify on a freshly-reset demo that hitting `/apis/default/api/version` returns JSON (not 401), and that `/portal/` is reachable.

## Land order
No dependencies. Independent of #120 — can merge in either order.

Assisted-by: Claude Code