### PR TITLE
chore(demo-farm): mark demo_ssh column as not used + drop dead read

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -260,12 +260,6 @@ IPADDRESS=$DOCKERDEMO
  echo "$dd"
  echo -n "dd option is " >> $LOG
  echo "$dd" >> $LOG
- # Grab demo ssh option
- ds=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 9`
- echo -n "ds option is "
- echo "$ds"
- echo -n "ds option is " >> $LOG
- echo "$ds" >> $LOG
  ppapi=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 10`
  echo -n "ppapi option is "
  echo "$ppapi"

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,4 +1,4 @@
-docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
 one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.3)
 one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.3)
 two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.2)


### PR DESCRIPTION
## Summary
Same shape as #122 did for `legacy_patching`. The `demo_ssh` column (column 9 of `ip_map_branch.txt`) is read into the `ds` shell variable, echoed twice, and never branched on or otherwise consumed. Zero references outside `demo_build.sh`.

## Changes

### `ip_map_branch.txt`
Rename column 9 header from `demo_ssh` to `demo_ssh(not used)`. Column values stay `0`. (Header rename rather than column drop avoids renumbering all the `cut -f N` reads for columns 10-18.)

### `demo_build.sh`
Drop the orphan `# Grab demo ssh option` comment, the `ds=` variable read, and the 4 echo lines.

## ⚠️ Stacked on #122

This branch contains #122's commit too (the two PRs both touch line 1 of `ip_map_branch.txt` — the header — so they can't be independent without conflict).

**Recommended merge order: land #122 first, then this PR.** Once #122 is in master, the GitHub-side rebase resolves the diff here down to just the changes described above.

If you'd rather merge in reverse order, that works too — there'd just be a manual conflict resolution on the header line when #122 is then merged.

## Diffstat
For the demo_ssh changes alone (the new commit on top of #122): 2 files changed, +1 / −7.
For the full PR view (including #122's commit until that lands): the larger diff includes the legacy_patching changes already under review in #122.

## Test plan
- [x] `bash -n demo_build.sh` — passes.
- [x] No remaining `\bds\b` references in `demo_build.sh`.
- [x] Column 9 still present in `ip_map_branch.txt` (header just renamed), all data rows unchanged.

Assisted-by: Claude Code