### PR TITLE
chore(demo-farm): reorder ip_map_branch.txt by purpose + add # comment guard

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -113,7 +113,13 @@ echo "error_log = $WEB/log/logPhp.txt" > /etc/php${PHP_VERSION_ABBR}/conf.d/99-d
 CAPSULES=/home/openemr/capsules
 GITMAIN=/home/openemr/git
 GITDEMOFARM=$GITMAIN/demo_farm_openemr
-GITDEMOFARMMAP=$GITDEMOFARM/ip_map_branch.txt
+# Strip '#' comment lines from ip_map_branch.txt up front so every
+# downstream `grep "$IPADDRESS" | cut -f N` lookup ignores them. The
+# file uses commented section headers (Production / UP FOR GRABS /
+# master / release / bookmarks) to keep groups visually organized.
+GITDEMOFARMMAP_SRC=$GITDEMOFARM/ip_map_branch.txt
+GITDEMOFARMMAP=$(mktemp)
+grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"
 PASSWORDRESETSCRIPT=$GITDEMOFARM/set_pass.php
 OPENEMRAPACHECONF=$GITDEMOFARM/openemr-alpine.conf
 GITTRANS=$GITMAIN/translations_development_openemr

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,25 +1,34 @@
 docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
-one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.3)
-one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.3)
-two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.2)
-two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Alpine 3.22 (with PHP 8.2)
-three	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.22 (with PHP 8.4)
-three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
-four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
-four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Beta With Demo Data
-four_b	https://github.com/rollingventures/openemr.git	bootstrap5-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/b	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Gamma With Demo Data
+# === Production ===
 five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
 five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo
 five_b	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.1.0 Production Demo
-six	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	six.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.22 (with PHP 8.4)
-six_a	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
+
+# === UP FOR GRABS ===
+four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data
+four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Beta With Demo Data
+four_b	https://github.com/rollingventures/openemr.git	bootstrap5-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/b	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Gamma With Demo Data
+
+# === Master demos (low → high PHP) ===
+two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.22 (with PHP 8.2)
+two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	two.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data on Alpine 3.22 (with PHP 8.2)
+one	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	one.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.3)
+one_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	one.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.3)
 seven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	seven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.4)
 seven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	seven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.4)
-eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
-eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
-ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[bookmark]
-ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 eleven	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	eleven.openemr.io	hey	branch	0	2	0	0	Public OpenEMR Development Demo on Alpine 3.23 (with PHP 8.5)
 eleven_a	https://github.com/openemr/openemr.git	master	0	1	0	0	demo_5_0_0_5.sql	0	1	eleven.openemr.io/a	hey	branch	5.0.0	2	0	0	Public OpenEMR Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
+
+# === Release demos (low → high version) ===
+six	https://github.com/openemr/openemr.git	rel-704	0	0	1	0	0	0	1	six.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 7.0.4 Development Demo on Alpine 3.22 (with PHP 8.4)
+six_a	https://github.com/openemr/openemr.git	rel-704	0	0	0	0	demo_5_0_0_5.sql	0	1	six.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 7.0.4 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
+three	https://github.com/openemr/openemr.git	rel-800	0	0	1	0	0	0	1	three.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.0.0 Development Demo on Alpine 3.22 (with PHP 8.4)
+three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	0	1	three.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.0.0 Development Demo With Demo Data On Alpine 3.22 (with PHP 8.4)
+eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
+eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
+
+# === Bookmarks ===
+ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[bookmark]
+ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
 edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[bookmark]
 edu_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]


### PR DESCRIPTION
## Summary
Reorder the rows in `ip_map_branch.txt` so the file reads top-to-bottom in the order an operator naturally thinks about the farm, with commented section headers between groups:

- `# === Production ===` — five
- `# === UP FOR GRABS ===` — four
- `# === Master demos (low → high PHP) ===` — two, one, seven, eleven
- `# === Release demos (low → high version) ===` — six, three, eight
- `# === Bookmarks ===` — ten, edu

Cluster names are unchanged — only the row order in the file is. Hostnames, DNS, certs, wiki links, and the `demoLibrary.source` case statement are untouched. As new releases ship the names will drift out of numeric order over time, and that's fine.

Add a 3-line pre-filter in `demo_build.sh` that strips `#` lines from `ip_map_branch.txt` into a temp file once at the top, so every downstream `grep "$IPADDRESS" | cut -f N` lookup ignores comment lines without touching the ~15 call sites. `IpMapBumper.php` already has its own `#` skip (line 69), so the PHP side is unaffected.

## Test plan
- [x] `diff <(awk 'NR>1 && $1!="" && $1!~/^#/' old | sort) <(awk 'NR>1 && $1!="" && $1!~/^#/' new | sort)` returns empty — every data row preserved verbatim.
- [x] Row count: 24 data rows before, 24 data rows after.
- [x] `grep -v '^#' ip_map_branch.txt | grep '<some-cluster-ip>' | cut -f N` returns the same field values as before for the same IP.