### PR TITLE
chore(demo-farm): comment cleanup pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ How do I set one of the "UP FOR GRABS" OpenEMR demos?
 -----------------------------------------------------
 1. Fork the https://github.com/openemr/demo_farm_openemr.git repo and make it your own
 2. Place your OpenEMR git repo information in the openemr_repo and branch items in
-   your ip_map_branch.txt for one of the UP FOR GRABS demo entries ("two"-"five").
+   your ip_map_branch.txt for one of the UP FOR GRABS demo entries (`four`, `four_a`, or `four_b`).
 3. Place a github pull request on your commit for number 2 above.
 4. After I bring in your github pull request, then place your repo and branch
    information in the pertinent UP FOR GRABS demo entries here:
@@ -22,12 +22,12 @@ This file is a tab delimited file for configuration of demos in the demo farm wi
 - serve_development_translations: set to 1 to have demo serve the daily build of translation set for download, set to 0 to turn this off (this setting has been deprecated)
 - use_development_translations: set to 1 to have demo use the daily build of translation set, set to 0 to turn this off
 - serve_packages: set to 1 to have demo serve zip/tgz packages of the build for download, set to 0 to turn this off
-- legacy_patching: set to 1 if you are using a legacy patched branch, such as rel-411,rel-410 etc. Note that rel-412 and above should be set to 0.
+- legacy_patching(not used): unused; column kept for backward column-order compatibility.
 - demo_data: set to 0 if no sql demo data file. If have a sql demo data file, then place the name of it here and place the file in the 'pieces' directory.
-- demo_ssh: set to the ssh package if using the offsite portal. Set to 0 if not connecting to offsite portal.
-- patient_portals: set to 0 to not use. set to 1 to set up the onsite patient portal demo.
+- demo_ssh(not used): unused; column kept for backward column-order compatibility.
+- patient_portals_and_api: set to 0 to not use. Set to 1 to enable the onsite patient portal demo and the REST / FHIR / OAuth APIs.
 - external_link: place the external web address to the demo here
-- root_sql_pass: set the root_sql_pass to use. if this is empty, then leave blank (however, only the deprecated demos will leave this empty).
+- root_sql_pass: set the root_sql_pass to use.
 - branch_tag: set this to `branch` when using a github branch and `tag` when using a github tag. 
 - demo_data_upgrade_from: when set demo_data above or capsule below, then place the OpenEMR version that the demo data was based on (so it will then be upgraded from that version).
 - fun_stuff: set this to randomly select a theme. Set to 0 to turn off. Set to 1 for when using OpenEMR version < 6.0 and set to 2 when using OpenEMR version 6.0 and greater.

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -666,9 +666,8 @@ IPADDRESS=$DOCKERDEMO
  fi
  
  if $packageServe ; then
-  #Package the development version into a tarball and zip file to be available thru web browser
-  # This is basically to allow download of most recent cvs version from the cvs Demo appliance
-  # It will also ease transfer/testing openemr on windows systems when using the Developer appliance
+  # Package the development version into a tarball and zip file to be
+  # available thru web browser (useful for testing on Windows etc.).
   echo "Creating OpenEMR Development packages"
   echo "Creating OpenEMR Development packages" >> $LOG
 

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -17,7 +17,6 @@
 # from openemr-devops's flex image set.
 #   - PHP 8.3 / 8.4 / 8.5 are served on Alpine 3.23
 #   - PHP 8.2          is served on Alpine 3.22
-# TODO: confirm exact tag scheme once openemr-devops publishes flex to Docker Hub.
 FLEX_IMAGE_3_23_PHP_8_5="openemr/openemr:flex-3.23-php-8.5"
 FLEX_IMAGE_3_23_PHP_8_4="openemr/openemr:flex-3.23-php-8.4"
 FLEX_IMAGE_3_23_PHP_8_3="openemr/openemr:flex-3.23-php-8.3"
@@ -44,7 +43,6 @@ startDemoWrapper() {
             count=2
             ;;
         three)
-            # FUTURE: 8.0.0 release demo (rel-800)
             image="${FLEX_IMAGE_3_22_PHP_8_4}"
             count=2
             ;;
@@ -57,7 +55,6 @@ startDemoWrapper() {
             count=3
             ;;
         six)
-            # FUTURE: 7.0.4 release demo (rel-704)
             image="${FLEX_IMAGE_3_22_PHP_8_4}"
             count=2
             ;;
@@ -66,12 +63,10 @@ startDemoWrapper() {
             count=2
             ;;
         eight)
-            # FUTURE: 8.1.0 release demo (rel-810)
             image="${FLEX_IMAGE_3_23_PHP_8_5}"
             count=2
             ;;
         ten)
-            # bookmark cluster
             image="${FLEX_IMAGE_3_23_PHP_8_5}"
             count=2
             ;;
@@ -80,7 +75,6 @@ startDemoWrapper() {
             count=2
             ;;
         edu)
-            # bookmark cluster
             image="${FLEX_IMAGE_3_23_PHP_8_5}"
             count=2
             ;;

--- a/docker/scripts/restartFarm.sh
+++ b/docker/scripts/restartFarm.sh
@@ -41,10 +41,9 @@ cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/trans
 
 # restart openemr demo docker containers
 # (note do not restart nginx, php, mysql, and phpmyadmin dockers)
+# (also note demo 'five' is at beginning since this is the production demo)
 # (also note doing the demo 'four' at end to be more efficient since it will set up 3 subdemos)
-# (also note demo 'five' is at beginning since this is the "main" demos)
-# (also note that demo 'edu' are just refreshing subdemos to allow persistent demos that
-#  do not reset; for example `edu empty` subdemo is not being reset)
+# (also note placed the `edu` demo docker at the end)
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh five
 sleep 30m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh one
@@ -65,8 +64,6 @@ bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven
 sleep 5m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh four
 sleep 5m
-#bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh edu empty
-#bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh edu a
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh edu
 
 # Reclaim disk: drop images that are no longer tagged (the prior

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -76,9 +76,9 @@ cp -r ~/demo_farm_openemr/docker/html/* ~/html/
 cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/translations/
 
 # bring in the dockers (note reverse-proxy needs to be done last)
+# (also note demo 'five' is at beginning since this is the production demo)
 # (also note doing the demo 'four' at end to be more efficient since it will set up 3 subdemos)
-# (also note demo 'five' is at beginning since this is the "main" demos)
-# (also note placed the `edu` demos docker at the end)
+# (also note placed the `edu` demo docker at the end)
 startMysql
 startPhpmyadmin
 startDemoWrapper "five"

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,4 +1,5 @@
 docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+
 # === Production ===
 five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
 five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo


### PR DESCRIPTION
## Summary
Sweep through the repo and prune comments that drifted out of date during the recent lean-down + flex pivot + column-retirement chain (#114 → #126).

### Edits
- **`ip_map_branch.txt`** — add blank line between header row and `# === Production ===` so every section is visually separated.
- **`docker/scripts/demoLibrary.source`** —
  - drop the `TODO: confirm exact tag scheme` line (resolved since #116, flex tags are in use)
  - drop `# FUTURE: ...` lines on `three` / `six` / `eight` (those cases serve the real `rel-704` / `rel-800` / `rel-810` demos, not future ones)
  - drop `# bookmark cluster` lines on `ten` / `edu` (the bookmark status already lives in the `description` column of `ip_map_branch.txt`)
- **`demo_build.sh`** — replace the `cvs Demo appliance` / `Developer appliance` comments above `packageServe`. The appliance mechanism was removed in #124; the packaging itself is still useful.
- **`docker/scripts/restartFarm.sh`** —
  - drop the stale "edu empty subdemo is not being reset" note (the cron-driven restart does a full container reset of edu, so every sub-instance is reset)
  - drop two dead commented-out `restartDemo.sh edu empty/a` lines
- **`docker/scripts/startFarm.sh`** + **`restartFarm.sh`** — align note ordering and wording across both scripts (production-first / four-end / edu-end), and refer to `five` as "the production demo" rather than `"main" demos`.
- **`README.md`** —
  - UP FOR GRABS row range was `"two"-"five"`; only `four` remains after the lean-down (#114), so fix to `four`, `four_a`, `four_b`
  - `legacy_patching` and `demo_ssh` column descriptions still described their old meaning; both columns are marked `(not used)` in the header now (per #122/#123) — update descriptions to match
  - `patient_portals` description renamed to `patient_portals_and_api` to match the column header, and the description now covers the REST / FHIR / OAuth API enablement (per #121)
  - drop the "only the deprecated demos will leave this empty" parenthetical on `root_sql_pass`

Pure comments/docs — no behavior change.

### Left alone deliberately
- `demoLibrary.source:271-275` `nine.openemr.io` / `fh-gmi.openemr.io` in `primeLetsencrypt` — deferred separately.
- `demo_build.sh:478-481` installer activation old vs new methods — still accurate for demos that pull older OpenEMR data.
- `demo_build.sh:547-549` innodb optimization TODO — documents real planned work.
- `demo_build.sh:720` `Zend code ... (added in version 4.1.3)` — version anchor is dated but the code path is gated by a file-existence check, so leaving as-is is safe.
- `demo_build.sh:751-754` commented-out `passReset` invocation — `set_pass.php` / `pass_reset` plumbing is being left untouched per prior call.
- `README.md` `pass_reset` description — left alone for the same reason.

## Test plan
- [x] `grep -rn "FUTURE\|bookmark cluster\|cvs Demo appliance\|Developer appliance\|edu empty subdemo is not being reset" .` returns no matches.
- [x] Section headers in `ip_map_branch.txt` are each preceded by a blank line.