### PR TITLE
chore(demo-farm): rename `bookmark` to `parked` for inactive demo slots

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -116,7 +116,7 @@ GITDEMOFARM=$GITMAIN/demo_farm_openemr
 # Strip '#' comment lines from ip_map_branch.txt up front so every
 # downstream `grep "$IPADDRESS" | cut -f N` lookup ignores them. The
 # file uses commented section headers (Production / UP FOR GRABS /
-# master / release / bookmarks) to keep groups visually organized.
+# master / release / parked) to keep groups visually organized.
 GITDEMOFARMMAP_SRC=$GITDEMOFARM/ip_map_branch.txt
 GITDEMOFARMMAP=$(mktemp)
 grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -28,8 +28,8 @@ three_a	https://github.com/openemr/openemr.git	rel-800	0	0	0	0	demo_5_0_0_5.sql	
 eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr.io	hey	branch	0	0	0	0	Public OpenEMR 8.1.0 Development Demo on Alpine 3.23 (with PHP 8.5)
 eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 
-# === Bookmarks ===
-ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[bookmark]
-ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
-edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[bookmark]
-edu_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	[bookmark]
+# === Parked ===
+ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[parked]
+ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[parked]
+edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[parked]
+edu_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	edu.openemr.io/a	hey	branch	5.0.0	0	0	0	[parked]


### PR DESCRIPTION
## Summary
\`bookmark\` reads as a browser bookmark on first encounter, when what it actually means is "DNS slot held but no active demo behind it". \`parked\` reads closer to a parked domain — held in place, not in active use.

Renames:
- \`ip_map_branch.txt\` — \`# === Bookmarks ===\` → \`# === Parked ===\` and four \`[bookmark]\` description values → \`[parked]\` (on \`ten\`, \`ten_a\`, \`edu\`, \`edu_a\`)
- \`demo_build.sh\` — one comment in the pre-filter block

No behavioral change; the cluster machinery doesn't key off these strings.

## Test plan
- [x] \`grep -ri "bookmark" .\` returns no matches.