### PR TITLE
chore(demo-farm): officially retire serve_development_translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This file is a tab delimited file for configuration of demos in the demo farm wi
 - docker_number: docker name of the OpenEMR demo
 - openemr_repo: set it to the openemr repo you want to grab code from
 - branch: git branch of the OpenEMR github repository
-- serve_development_translations: set to 1 to have demo serve the daily build of translation set for download, set to 0 to turn this off (this setting has been deprecated)
+- serve_development_translations(not used): unused; column kept for backward column-order compatibility.
 - use_development_translations: set to 1 to have demo use the daily build of translation set, set to 0 to turn this off
 - serve_packages: set to 1 to have demo serve zip/tgz packages of the build for download, set to 0 to turn this off
 - legacy_patching(not used): unused; column kept for backward column-order compatibility.

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -87,9 +87,6 @@ else
  lightResetDemo=$1
 fi
 
-# PUBLIC REPOS (note the openemr repo is mapped in GITDEMOFARMMAP)
-TRANSLATIONSREPO=https://github.com/openemr/translations_development_openemr.git
-
 # PATH VARIABLES AND CREATED NEEDED DIRS
 # Demo farm runs every cluster on the flex (Alpine) base image as of #116,
 # so the web root is always Alpine's /var/www/localhost/htdocs.
@@ -123,7 +120,6 @@ grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"
 PASSWORDRESETSCRIPT=$GITDEMOFARM/set_pass.php
 OPENEMRAPACHECONF=$GITDEMOFARM/openemr-alpine.conf
 GITTRANS=$GITMAIN/translations_development_openemr
-TRANSSERVEDIR=$WEB/translations
 TMPDIR=/tmp/openemr-tmp
 
 if $lightReset; then
@@ -242,12 +238,6 @@ IPADDRESS=$DOCKERDEMO
  echo "$GITBRANCH"
  echo -n "git branch is " >> $LOG
  echo "$GITBRANCH" >> $LOG
- # Grab serve development translation set option
- sdt=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 4`
- echo -n "sdt option is "
- echo "$sdt"
- echo -n "sdt option is " >> $LOG
- echo "$sdt" >> $LOG
  # Grab use development translation set option
  udt=`cat $GITDEMOFARMMAP | grep "$IPADDRESS" | tr -d '\n' | cut -f 5`
  echo -n "udt option is "
@@ -308,12 +298,6 @@ IPADDRESS=$DOCKERDEMO
  echo "$useCapsule" >> $LOG
 
  # SET OPTIONS
- # set if serve development translation set
- if [ "$sdt" == "1"  ]; then
-  translationServe=true;
- else
-  translationServe=false;
- fi
  # set if use development translation set
  if [ "$udt" == "1"  ]; then
   translationsDevelopment=true;
@@ -388,16 +372,6 @@ IPADDRESS=$DOCKERDEMO
    cd $GIT
    git checkout $GITBRANCH
    cd $GITMAIN
-  fi
-  if $translationServe ; then
-   # download the translations git repo and place the set sql file for serving
-   echo "Placing OpenEMR Development translation set"
-   echo "Placing OpenEMR Development translation set" >> $LOG
-   git clone $TRANSLATIONSREPO
-   mkdir -p $TRANSSERVEDIR
-   cp $GITTRANS/languageTranslations_utf8.sql $TRANSSERVEDIR/
-   echo "Done Placing OpenEMR Development translation set"
-   echo "Done Placing OpenEMR Development translation set" >> $LOG
   fi
  else
   echo "ERROR, The OpenEMR git repository already exist"

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,4 +1,4 @@
-docker_number	openemr_repo	branch	serve_development_translations	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
 
 # === Production ===
 five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo


### PR DESCRIPTION
## Summary
Apply the same `(not used)` treatment to `serve_development_translations` that #122 / #123 applied to `legacy_patching` / `demo_ssh`.

Why this column is dead:
- Every row has `serve_development_translations = 0` after the lean-down chain.
- The consumer block was non-functional anyway — `git clone $TRANSLATIONSREPO` ran into `$GITMAIN`, which already exists as a **read-only** volume mount of the same path (see the `startDemo()` `-v` flag in `demoLibrary.source`). Had any row been set to `1`, the clone would have errored.

### Edits
- `ip_map_branch.txt` — tag header column as `serve_development_translations(not used)`.
- `demo_build.sh` —
  - drop the `sdt = cut -f 4` lookup + its echo trail
  - drop the `translationServe` boolean setter
  - drop the `if $translationServe ; then ... fi` block (the git clone + cp + mkdir)
  - drop the now-orphaned `TRANSLATIONSREPO` and `TRANSSERVEDIR` variables
- `README.md` — replace the column description with the same `unused; column kept for backward column-order compatibility.` wording used for `legacy_patching` / `demo_ssh`.

`GITTRANS` stays — `use_development_translations` (col 5) reads from the volume-mounted path.

3 files, +2 / -28.

## Test plan
- [x] `bash -n demo_build.sh` passes.
- [x] `grep -n "sdt\b\|translationServe\|TRANSSERVEDIR\|TRANSLATIONSREPO" demo_build.sh` returns no matches.
- [x] `awk -F'\t' 'NR>1 && $1!~/^#/ && $1!="" {print $4}' ip_map_branch.txt | sort -u` confirms every data row already had `0`.