### PR TITLE
chore(demo-farm): bring `nine` back as a parked cluster

### DIFF
--- a/docker/html/admin/ajax_admin_demo_farm.php
+++ b/docker/html/admin/ajax_admin_demo_farm.php
@@ -51,6 +51,9 @@ if (!empty($_POST['procedure'])) {
         case 'status_eight_openemr':
             collectProcedure('docker logs eight-openemr', $output);
             break;
+        case 'status_nine_openemr':
+            collectProcedure('docker logs nine-openemr', $output);
+            break;
         case 'status_ten_openemr':
             collectProcedure('docker logs ten-openemr', $output);
             break;
@@ -149,6 +152,15 @@ if (!empty($_POST['procedure'])) {
             break;
         case 'refresh_eight_a_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eight a', $output);
+            break;
+        case 'restart_nine_openemr':
+            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh nine', $output);
+            break;
+        case 'refresh_nine_openemr':
+            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh nine empty', $output);
+            break;
+        case 'refresh_nine_a_openemr':
+            collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh nine a', $output);
             break;
         case 'restart_ten_openemr':
             collectProcedure('bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh ten', $output);

--- a/docker/html/admin/index.php
+++ b/docker/html/admin/index.php
@@ -79,6 +79,7 @@
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_six_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Six Status</button>
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_seven_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Seven Status</button>
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_eight_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Eight Status</button>
+                                                            <button type="button" class="btn btn-primary procedure-demo" id="status_nine_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Nine Status</button>
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_ten_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Ten Status</button>
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_eleven_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Eleven Status</button>
                                                             <button type="button" class="btn btn-primary procedure-demo" id="status_edu_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Status">Edu Status</button>
@@ -375,6 +376,28 @@
                                                     <div class="btn-group-vertical form-group">
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_eight_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eight Refresh</button>
                                                         <button type="button" class="btn btn-primary procedure-demo" id="refresh_eight_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Eight A Refresh</button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="panel panel-default">
+                                    <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapseNine" aria-expanded="false" aria-controls="collapseNine">
+                                        Nine Toggle
+                                    </button>
+                                    <div class="collapse" id="collapseNine">
+                                        <div class="panel-body">
+                                            <div class="card card-body">
+                                                <div class="row col-xs-12">
+                                                    <div class="btn-group-vertical form-group">
+                                                        <button type="button" class="btn btn-primary procedure-demo" id="restart_nine_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Restart">Nine Restart</button>
+                                                    </div>
+                                                </div>
+                                                <div class="row col-xs-12">
+                                                    <div class="btn-group-vertical form-group">
+                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_nine_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Nine Refresh</button>
+                                                        <button type="button" class="btn btn-primary procedure-demo" id="refresh_nine_a_openemr" data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> Processing Refresh">Nine A Refresh</button>
                                                     </div>
                                                 </div>
                                             </div>

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -53,6 +53,10 @@ startDemoWrapper() {
             image="openemr/openemr:flex-3.23-php-8.5"
             count=2
             ;;
+        nine)
+            image="openemr/openemr:flex-3.23-php-8.5"
+            count=2
+            ;;
         ten)
             image="openemr/openemr:flex-3.23-php-8.5"
             count=2

--- a/docker/scripts/restartFarm.sh
+++ b/docker/scripts/restartFarm.sh
@@ -58,6 +58,8 @@ bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh seven
 sleep 5m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eight
 sleep 5m
+bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh nine
+sleep 5m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh ten
 sleep 5m
 bash ~/demo_farm_openemr/docker/scripts/restartDemo.sh eleven

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -95,6 +95,8 @@ startDemoWrapper "seven"
 sleep 5m
 startDemoWrapper "eight"
 sleep 5m
+startDemoWrapper "nine"
+sleep 5m
 startDemoWrapper "ten"
 sleep 5m
 startDemoWrapper "eleven"

--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -29,6 +29,8 @@ eight	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	0	0	1	eight.openemr
 eight_a	https://github.com/openemr/openemr.git	rel-810	0	0	0	0	demo_5_0_0_5.sql	0	1	eight.openemr.io/a	hey	branch	5.0.0	0	0	0	Public OpenEMR 8.1.0 Development Demo With Demo Data On Alpine 3.23 (with PHP 8.5)
 
 # === Parked ===
+nine	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	nine.openemr.io	hey	branch	0	0	0	0	[parked]
+nine_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	nine.openemr.io/a	hey	branch	5.0.0	0	0	0	[parked]
 ten	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	ten.openemr.io	hey	branch	0	0	0	0	[parked]
 ten_a	https://github.com/openemr/openemr.git	master	0	0	0	0	demo_5_0_0_5.sql	0	1	ten.openemr.io/a	hey	branch	5.0.0	0	0	0	[parked]
 edu	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	edu.openemr.io	hey	branch	0	0	0	0	[parked]


### PR DESCRIPTION
## Summary
Bring `nine` back into the farm as a parked cluster (joining `ten` and `edu` in the Parked section).

The supporting infrastructure was already in place from the lean-down chain — it was kept around in anticipation of exactly this:
- nginx server block for `nine.openemr.io` (`docker/nginx/nginx.conf:387`)
- `-d nine.openemr.io` SAN entry in `primeLetsencrypt()` (`demoLibrary.source:252`)
- `"nine"` whitelist entries in `restartDemo.sh:25` / `snapshotDemo.sh:25`

### Edits

**Cluster wiring**
- `ip_map_branch.txt` — add `nine` and `nine_a` rows in the Parked section, placed before `ten` so the section reads nine → ten → edu. Mirrors the shape of `ten` (Alpine 3.23 / PHP 8.5, master branch, `_a` row carries demo data via `demo_5_0_0_5.sql`).
- `docker/scripts/demoLibrary.source` — `nine)` case block in `startDemoWrapper` between `eight)` and `ten)` so the case statement stays in cluster-number order. Same image + count as the other parked clusters.
- `docker/scripts/startFarm.sh` + `docker/scripts/restartFarm.sh` — `startDemoWrapper "nine"` / `restartDemo.sh nine` invocations between `eight` and `ten`.

**Admin UI**
- `docker/html/admin/ajax_admin_demo_farm.php` — `status_nine_openemr`, `restart_nine_openemr`, `refresh_nine_openemr`, `refresh_nine_a_openemr` cases, slotted between eight and ten.
- `docker/html/admin/index.php` — Nine Status button in the Status row, plus a Nine Toggle collapsible panel with Restart / Refresh / Refresh A buttons, mirroring the Eight and Ten panels.

6 files, +45 / 0.

## Test plan
- [x] `bash -n` passes on `demoLibrary.source`, `startFarm.sh`, `restartFarm.sh`.
- [x] No surface left behind: nginx server block, cert SAN, validation guards already in place.
- [x] Admin UI cases + buttons mirror the eight/ten patterns exactly.