### PR TITLE
chore(demo-farm): remove fh-gmi cruft

### DIFF
--- a/docker/html/edu/index.html
+++ b/docker/html/edu/index.html
@@ -30,7 +30,6 @@
             <ul class="nav nav-tabs">
                 <li class="active"><a data-toggle="tab" href="#instructional">Instructional EDU Projects</a></li>
                 <li><a data-toggle="tab" href="#research">Research EDU Projects</a></li>
-                <li><a data-toggle="tab" href="#charity">Charity EDU Projects</a></li>
             </ul>
         </div>
         <div class="tab-content">
@@ -77,32 +76,6 @@
                                             <div class="row col-xs-12">
                                                 <p><b>Under Construction</b></p>
                                                 <p>(following demo is reserved for this project: <a href="https://edu.openemr.io/b/openemr/index.php" target="_blank">https://edu.openemr.io/b/openemr</a> )</p>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div id="charity" class="tab-pane fade">
-                <div class="row text-center">
-                    <h3>Charity EDU Projects</h3>
-                </div>
-                <div class="row">
-                    <div class="col-xs-12">
-                        <div class="panel-group">
-                            <div class="panel panel-default">
-                                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapseFhgmi" aria-expanded="false" aria-controls="collapseFhgmi">
-                                    Florida Hospital Global Missions Initiative Project - Toggle
-                                </button>
-                                <div class="collapse" id="collapseFhgmi">
-                                    <div class="panel-body">
-                                        <div class="card card-body">
-                                            <div class="row col-xs-12">
-                                                <p><b>Under Construction</b></p>
-                                                <p>(following demo is reserved for this project: <a href="https://fh-gmi.openemr.io/openemr/index.php" target="_blank">https://fh-gmi.openemr.io/openemr</a> )</p>
                                             </div>
                                         </div>
                                     </div>

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -150,7 +150,7 @@ http {
         listen 80;
         listen 443 ssl;
 
-        server_name edu.openemr.io fh-gmi.openemr.io;
+        server_name edu.openemr.io;
 
         location ^~ /.well-known {
             allow all;

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -256,8 +256,7 @@ primeLetsencrypt () {
                -d nine.openemr.io \
                -d ten.openemr.io \
                -d eleven.openemr.io \
-               -d edu.open-emr.org \
-               -d fh-gmi.openemr.io
+               -d edu.open-emr.org
 }
 
 renewLetsencrypt () {


### PR DESCRIPTION
## Summary
Florida Hospital Global Missions Initiative was a parked "Charity EDU" slot that never went live. Drop the remaining references across the repo:

- `docker/nginx/nginx.conf` — drop `fh-gmi.openemr.io` from the `server_name` alias on edu's server block; edu is now the only hostname served by that block.
- `docker/scripts/demoLibrary.source` — drop `-d fh-gmi.openemr.io` from the `primeLetsencrypt()` SAN list (and the trailing backslash on the prior `edu.open-emr.org` line so it terminates).
- `docker/html/edu/index.html` — drop the "Charity EDU Projects" nav tab and its sole tab-pane (the fhgmi "Under Construction" panel was the only content).

3 files, +2 / -30.

## Test plan
- [x] `grep -rni "fh-gmi\|fhgmi" .` returns no matches.
- [x] `bash -n docker/scripts/demoLibrary.source` passes.