### PR TITLE
chore(demo-farm): revert production demos from v8_1_0 back to v8_0_0_3

### DIFF
--- a/ip_map_branch.txt
+++ b/ip_map_branch.txt
@@ -1,9 +1,9 @@
 docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
 
 # === Production ===
-five	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.1.0 Production Demo
-five_a	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.1.0 Production Demo
-five_b	https://github.com/openemr/openemr.git	v8_1_0	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.1.0 Production Demo
+five	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	tag	5.0.0	0	4	0	Public OpenEMR 8.0.0 Production Demo
+five_a	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/a	hey	tag	5.0.0	0	4	0	Alternate Public OpenEMR 8.0.0 Production Demo
+five_b	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io/b	hey	tag	5.0.0	0	4	0	Another Alternate Public OpenEMR 8.0.0 Production Demo
 
 # === UP FOR GRABS ===
 four	https://github.com/rollingventures/openemr.git	feat/webpack-replace-gulp	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io	hey	branch	5.0.0	0	0	0	UP FOR GRABS Public OpenEMR Demo - Alpha With Demo Data


### PR DESCRIPTION
## Summary

Reverts the three production demo rows (five, five_a, five_b) from
`v8_1_0` back to `v8_0_0_3`. Description text reverts from "OpenEMR
8.1.0 Production Demo" back to "OpenEMR 8.0.0 Production Demo".

## Why

8.1.0 was cut as a GitHub artifact only — the release ended up being
buggy and was pulled. Production demos were prematurely seeded onto
`v8_1_0` in #111 (anticipating 8.1.0 going GA). Rolling back until the
8.1.x line actually ships its first real release (planned: 8.1.1 from
rel-810).

## Diff

```diff
-five    ... v8_1_0  ... Public OpenEMR 8.1.0 Production Demo
-five_a  ... v8_1_0  ... Alternate Public OpenEMR 8.1.0 Production Demo
-five_b  ... v8_1_0  ... Another Alternate Public OpenEMR 8.1.0 Production Demo
+five    ... v8_0_0_3 ... Public OpenEMR 8.0.0 Production Demo
+five_a  ... v8_0_0_3 ... Alternate Public OpenEMR 8.0.0 Production Demo
+five_b  ... v8_0_0_3 ... Another Alternate Public OpenEMR 8.0.0 Production Demo
```

Matches the pre-#111 state exactly.

## After 8.1.1 ships

Re-seed these rows to `v8_1_1` via the same manual edit pattern
(another #111-style PR). `bump-tag.yml` only advances tag rows whose
existing `MAJOR.MINOR` matches the new tag — so the first release on
a new minor line is still a manual seeding moment, regardless of any
automation downstream.

## Test plan

- [ ] CI green on this PR.
- [ ] Next demo-farm orchestrator run rebuilds five / five_a / five_b
      from the v8_0_0_3 tag content; `demo.openemr.io` (and the /a
      /b mirrors) serve the 8.0.0 image again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration settings to reference a revised repository branch version for applicable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->