### PR TITLE
chore(demo-farm): align cluster five flex image with rel-800's Dockerfile (3.22/8.4)

### DIFF
--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -38,7 +38,7 @@ startDemoWrapper() {
             count=3
             ;;
         five)
-            image="openemr/openemr:flex-3.23-php-8.5"
+            image="openemr/openemr:flex-3.22-php-8.4"
             count=3
             ;;
         six)


### PR DESCRIPTION
## Summary

Follow-up to #133. Aligns cluster `five`'s flex base image
(`demoLibrary.source` `startDemoWrapper`) with rel-800's
`docker/release/Dockerfile` ARGs:

```diff
         five)
-            image=\"openemr/openemr:flex-3.23-php-8.5\"
+            image=\"openemr/openemr:flex-3.22-php-8.4\"
             count=3
             ;;
```

Cluster `five` (production demos five / five_a / five_b in
`ip_map_branch.txt`) points at `v8_0_0_3` after the #133 revert. But
the flex base was still on Alpine 3.23 + PHP 8.5 — rel-810's combo,
not rel-800's.

## Source-of-truth check

| Source | Alpine | PHP |
|---|---|---|
| `openemr/openemr` rel-800 `docker/release/Dockerfile` (what v8_0_0_3 production image ships with) | 3.22 | 8.4 |
| `openemr/openemr` rel-810 `docker/release/Dockerfile` (what v8_1_0 production image ships with) | 3.23 | 8.5 |
| demo_farm cluster `three` (rel-800 development demo, ALREADY correct) | 3.22 | 8.4 |
| demo_farm cluster `eight` (rel-810 development demo, ALREADY correct) | 3.23 | 8.5 |
| demo_farm cluster `five` BEFORE this PR | 3.23 | 8.5 (mismatched with v8_0_0_3 target) |
| demo_farm cluster `five` AFTER this PR | 3.22 | 8.4 (aligned with v8_0_0_3 target) |

After this lands, `demo.openemr.io` (+ /a + /b mirrors) run 8.0.0.3
source on the same runtime combo (Alpine 3.22 + PHP 8.4) that the
released `openemr/openemr:8.0.0.3` image ships with. Demo consumers
see the actual production environment, not a newer one.

## Drift history (pre-existing, not introduced by #133)

Cluster `five` has been on `flex-3.23-php-8.5` continuously since
before #111:

- Pre-#111 (production at v8_0_0_3, Alpine 3.22 + PHP 8.4): mismatched
  3.23/8.5 vs 3.22/8.4
- #111-era (production at v8_1_0, Alpine 3.23 + PHP 8.5): coincidentally
  correct
- Post-#133 (production back at v8_0_0_3): mismatched again

#133 didn't introduce this — it took us back to the pre-existing
mismatch state. This PR closes the loop.

## Lessons for future production-demo bumps

When changing a `branch_tag=tag` row in `ip_map_branch.txt` to point
at a new release, also check the corresponding cluster's flex image
in `demoLibrary.source` against the new tag's source repo's
`docker/release/Dockerfile` ARGs (ALPINE_VERSION + PHP_VERSION). The
demo's runtime should match what the released image ships with.

Worth flagging as a candidate for auto-generation: ip_map_branch.txt
production-demo rows + demoLibrary.source flex-image mappings could
be derived from openemr/openemr's `release-targets.yml` + per-branch
Dockerfile combos. A scheduled or branch-cut-triggered PR-bot in this
repo could keep both in sync mechanically. Captured in the
release-mechanism gaps doc on openemr/openemr (PR #12599) under
future-work.

## Test plan

- [ ] CI green here.
- [ ] After merge: next demo-farm orchestrator cycle pulls
      `flex-3.22-php-8.4` and rebuilds five / five_a / five_b on the
      aligned runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the demo cluster Docker image version for demonstration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->