### PR TITLE
ci(dependabot): add minimal config for github-actions weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: ci
+      include: scope
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Add a minimal `.github/dependabot.yml` to watch GitHub Actions versions in this repo's workflows, weekly schedule.

## Why

Both sibling repos already have dependabot watching their workflows:
- **openemr/openemr** — `github-actions` ecosystem (weekly, Mondays)
- **openemr-devops** — `github-actions` ecosystem (daily)

This repo currently has none, so action refs like `actions/checkout@v7` and `actions/upload-artifact@v7` float silently to whatever v7.x.y GitHub publishes — no PR notification on new majors or behavior-affecting bumps.

## Scope

Intentionally minimal: just `github-actions`, weekly. Can be expanded later if/when the repo grows other ecosystems (npm, docker, etc.).

## Test plan

- [ ] Dependabot config validates on GitHub (visible in repo Settings → Code security & analysis)
- [ ] First dependabot scan runs on next Monday's schedule (or triggered manually from Insights → Dependency graph → Dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated update tracking for repository GitHub Actions on a weekly schedule.
  * Update pull requests will now be labeled consistently and limited to a small number of open items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->