### PR TITLE
feat(auto-derive): open reconciliation PR on diff (write + PR mode)

### DIFF
--- a/.github/workflows/derive-ip-map.yml
+++ b/.github/workflows/derive-ip-map.yml
@@ -27,6 +27,13 @@ on:
           - reconcile
           - dry-run
         default: reconcile
+  pull_request:
+    paths:
+      - tools/auto-derive/**
+      - .github/workflows/derive-ip-map.yml
+      - demo_build.sh
+      - ip_map_branch.txt
+      - docker/scripts/demoLibrary.source
 
 concurrency:
   group: derive-ip-map-scheduled
@@ -35,11 +42,15 @@ concurrency:
 jobs:
   reconcile:
     # Daily schedule, or explicit reconcile dispatch. Guarded to upstream repo
-    # so forks don't accidentally try to open PRs against themselves.
+    # so forks don't accidentally try to open PRs against themselves. Also
+    # gated on the fixture test job: a broken algorithm must not get to
+    # force-push or open a PR.
+    needs: test
     if: |
-      github.repository_owner == 'openemr'
+      needs.test.result == 'success'
+      && github.repository_owner == 'openemr'
       && github.repository == 'openemr/demo_farm_openemr'
-      && (github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'reconcile')
+      && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'reconcile'))
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -51,6 +62,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # Pin to master so a workflow_dispatch fired from a topic branch
+          # doesn't carry unrelated commits into the bot's reconciliation
+          # branch base.
+          ref: master
           fetch-depth: 0
           # NOTE: persist-credentials stays default (true) so `git push` works.
           # Upstream openemr reads happen via curl inside derive.sh, not git.
@@ -153,7 +168,7 @@ jobs:
           # branch -- diff target is the local `master` ref which still tracks
           # origin/master via fetch-depth: 0. We compute the diff from working
           # tree at HEAD of RECONCILE_BRANCH (committed) vs master.
-          stat="$(git diff master -- ip_map_branch.txt docker/scripts/demoLibrary.source --stat)"
+          stat="$(git diff --stat master -- ip_map_branch.txt docker/scripts/demoLibrary.source)"
           full_diff="$(git diff master -- ip_map_branch.txt docker/scripts/demoLibrary.source)"
           # Write PR body to a file so YAML block-scalar indentation doesn't
           # interfere with the markdown body (and we can pass via --body-file).

--- a/.github/workflows/derive-ip-map.yml
+++ b/.github/workflows/derive-ip-map.yml
@@ -1,33 +1,209 @@
-name: Derive ip_map (dry-run)
+name: Derive ip_map (reconcile)
 
-# Dry-run reconciliation of ip_map_branch.txt + docker/scripts/demoLibrary.source
-# against upstream openemr/openemr state. Outputs a diff artifact + step summary.
+# Reconciliation of ip_map_branch.txt + docker/scripts/demoLibrary.source
+# against upstream openemr/openemr state.
 #
-# PR #1 scope: NO live PR opening (that's PR #2). NO retirement of bump-tag.yml
-# (that's PR #3). This workflow just runs the algorithm in dry-run mode so the
-# diff is visible before any live mutation happens.
+# Daily schedule runs in `reconcile` mode: writes the reconciled files, and
+# if there is a diff vs master in either output file, force-pushes a stable
+# branch `auto-derive/reconciliation` and opens (or updates) a PR. If the
+# next day's run shows no diff, the open PR is closed automatically.
+#
+# `workflow_dispatch` defaults to `reconcile` too; choose `dry-run` to
+# preview the algorithm's output without any branch/PR side effects.
+#
+# PR #1 scope: NO live PR opening (dry-run only). PR #2 (this): adds the
+# write + auto-PR mode. PR #3 will retire bump-tag.yml.
 
 on:
-  pull_request:
-    paths:
-      - 'tools/auto-derive/**'
-      - '.github/workflows/derive-ip-map.yml'
   schedule:
     # Daily 07:00 UTC, 1h after openemr's docker-release-orchestrator (06:00).
     - cron: '0 7 * * *'
   workflow_dispatch:
-
-permissions:
-  contents: read
+    inputs:
+      mode:
+        description: 'reconcile (write + PR) or dry-run (preview only)'
+        type: choice
+        options:
+          - reconcile
+          - dry-run
+        default: reconcile
 
 concurrency:
-  group: derive-ip-map-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'scheduled' }}
+  group: derive-ip-map-scheduled
   cancel-in-progress: false
 
 jobs:
-  derive:
-    if: github.repository_owner == 'openemr' && github.repository == 'openemr/demo_farm_openemr'
+  reconcile:
+    # Daily schedule, or explicit reconcile dispatch. Guarded to upstream repo
+    # so forks don't accidentally try to open PRs against themselves.
+    if: |
+      github.repository_owner == 'openemr'
+      && github.repository == 'openemr/demo_farm_openemr'
+      && (github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'reconcile')
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      RECONCILE_BRANCH: auto-derive/reconciliation
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # NOTE: persist-credentials stays default (true) so `git push` works.
+          # Upstream openemr reads happen via curl inside derive.sh, not git.
+
+      - name: Install yq
+        run: |
+          set -euo pipefail
+          YQ_VERSION=v4.53.3
+          curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Configure git identity
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Run derive.sh --write
+        run: |
+          set -euo pipefail
+          ./tools/auto-derive/derive.sh --write
+
+      - name: Check for changes vs master (scoped to output files)
+        id: diff
+        run: |
+          set -euo pipefail
+          # Scope diff detection to the bot's two output files only. This way
+          # an unrelated edit to tools/auto-derive/ etc. on master won't trip
+          # the bot into opening a reconciliation PR for changes it didn't make.
+          if git diff --quiet -- ip_map_branch.txt docker/scripts/demoLibrary.source; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No reconciliation diff vs master in output files."
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Reconciliation diff detected in output files:"
+            git diff --stat -- ip_map_branch.txt docker/scripts/demoLibrary.source
+          fi
+
+      - name: Find existing reconciliation PR (if any)
+        id: existing_pr
+        run: |
+          set -euo pipefail
+          pr_number="$(gh pr list \
+            --head "$RECONCILE_BRANCH" \
+            --base master \
+            --state open \
+            --json number \
+            --jq '.[0].number // ""')"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          if [[ -n "$pr_number" ]]; then
+            echo "Existing reconciliation PR: #$pr_number"
+          else
+            echo "No existing reconciliation PR."
+          fi
+
+      - name: Close existing PR if no diff
+        if: steps.diff.outputs.has_changes == 'false' && steps.existing_pr.outputs.pr_number != ''
+        run: |
+          set -euo pipefail
+          gh pr close "${{ steps.existing_pr.outputs.pr_number }}" \
+            --comment "Closing automatically: latest reconciliation against upstream openemr master shows no diff vs master. The branch becomes obsolete; a future reconciliation with a real diff will open a fresh PR."
+          # Also delete the branch on remote since it's now stale.
+          git push origin --delete "$RECONCILE_BRANCH" || true
+
+      - name: Force-push reconciliation branch
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Capture a fresh dry-run report header for the commit message.
+          # Cheap re-run; upstream fetches in derive.sh are short.
+          summary="$(./tools/auto-derive/derive.sh --dry-run | sed -n '/^## demo_farm auto-derive/,/^=== /p' | head -n 20 || true)"
+          git checkout -B "$RECONCILE_BRANCH"
+          # Stage only the bot's output files; never sweep unrelated changes.
+          git add ip_map_branch.txt docker/scripts/demoLibrary.source
+          # Write the commit message to a tempfile so we don't have to wrestle
+          # with YAML block-scalar indentation eating a bash heredoc.
+          msg_file="$(mktemp)"
+          {
+            printf 'chore(auto-derive): reconcile demo_farm against upstream openemr master\n\n'
+            printf 'This commit is auto-generated by the derive-ip-map workflow.\n'
+            printf 'Run: %s\n\n' "$RUN_URL"
+            printf '%s\n' "$summary"
+          } > "$msg_file"
+          git commit -F "$msg_file"
+          # --force-with-lease is safe even if a prior PR was merged + branch
+          # deleted: lease is against our local view of the remote ref.
+          git push --force-with-lease origin "$RECONCILE_BRANCH"
+
+      - name: Build PR body
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Render diff against master BEFORE we switch off the reconciliation
+          # branch -- diff target is the local `master` ref which still tracks
+          # origin/master via fetch-depth: 0. We compute the diff from working
+          # tree at HEAD of RECONCILE_BRANCH (committed) vs master.
+          stat="$(git diff master -- ip_map_branch.txt docker/scripts/demoLibrary.source --stat)"
+          full_diff="$(git diff master -- ip_map_branch.txt docker/scripts/demoLibrary.source)"
+          # Write PR body to a file so YAML block-scalar indentation doesn't
+          # interfere with the markdown body (and we can pass via --body-file).
+          body_file="${RUNNER_TEMP:-/tmp}/pr-body.md"
+          {
+            printf '**Auto-generated reconciliation** by [derive-ip-map](%s) against upstream openemr master state at %s.\n\n' \
+              "$RUN_URL" "$(date -u +'%Y-%m-%d %H:%M UTC')"
+            printf '## Change summary\n\n'
+            printf '```\n%s\n```\n\n' "$stat"
+            printf '<details>\n<summary>Full diff</summary>\n\n'
+            printf '```diff\n%s\n```\n\n' "$full_diff"
+            printf '</details>\n\n'
+            printf '## Behavior\n\n'
+            printf 'This PR is **idempotent across daily runs**. If left unmerged, the bot will:\n'
+            printf '- Force-push fresh reconciliation tomorrow (if upstream state has drifted further)\n'
+            printf '- Close this PR automatically (if upstream reverts and the diff disappears)\n\n'
+            printf 'Merging will land the reconciled state and the bot will stop nagging until the next genuine drift.\n\n'
+            printf '## CI note\n\n'
+            printf 'This PR was created by `GITHUB_TOKEN`, so downstream workflows (rabbit, CI) do NOT run on it automatically. PR #135'"'"'s fixture suite is the authoritative validator for the algorithm; if you want to manually run CI here, push an empty commit.\n'
+          } > "$body_file"
+          echo "PR body written to $body_file ($(wc -c <"$body_file") bytes)"
+
+      - name: Create or update PR
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          EXISTING_PR: ${{ steps.existing_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          title="[auto-derive] reconcile demo_farm against upstream openemr master"
+          body_file="${RUNNER_TEMP:-/tmp}/pr-body.md"
+          if [[ -n "$EXISTING_PR" ]]; then
+            gh pr edit "$EXISTING_PR" \
+              --title "$title" \
+              --body-file "$body_file"
+            echo "Updated existing PR #$EXISTING_PR"
+          else
+            gh pr create \
+              --base master \
+              --head "$RECONCILE_BRANCH" \
+              --title "$title" \
+              --body-file "$body_file"
+          fi
+
+  dry-run:
+    # Manual dry-run inspection without writing/pushing. Useful for debugging
+    # the bot's algorithm without affecting any PR state.
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'dry-run' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -43,8 +219,7 @@ jobs:
           chmod +x /usr/local/bin/yq
           yq --version
 
-      - name: Run derive.sh in dry-run mode
-        id: derive
+      - name: Run derive.sh --dry-run
         run: |
           set -euo pipefail
           ./tools/auto-derive/derive.sh --dry-run | tee /tmp/derive-output.txt
@@ -58,10 +233,12 @@ jobs:
           if-no-files-found: warn
 
   test:
-    # Fixture test suite -- validates derive.sh against canned scenarios.
-    # Runs on PR + schedule + dispatch so a broken algorithm is caught
-    # before it would produce a misleading dry-run diff.
+    # Fixture test suite -- unchanged from PR #1. Validates derive.sh against
+    # canned scenarios so a broken algorithm is caught before it would produce
+    # a misleading reconciliation diff.
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -79,4 +256,5 @@ jobs:
 
       - name: Run fixture test suite
         run: |
+          set -euo pipefail
           ./tools/auto-derive/fixtures-and-tests/test.sh

--- a/tools/auto-derive/README.md
+++ b/tools/auto-derive/README.md
@@ -75,7 +75,7 @@ See the G6 design in the [release-mechanism migration plan](https://github.com/o
 # dry-run against your demo_farm checkout
 ./derive.sh --dry-run
 
-# write mode (mutates files in place -- PR #2 will use this)
+# write mode (mutates files in place -- this is what the daily reconcile uses)
 ./derive.sh --write
 ```
 
@@ -129,12 +129,44 @@ WS=$(mktemp -d) && cp -a fixtures-and-tests/fixtures/<your-name>/current/. $WS/ 
   cp -a $WS/. fixtures-and-tests/fixtures/<your-name>/expected/ && rm -rf $WS
 ```
 
+## Daily reconcile + auto-PR
+
+The `derive-ip-map` workflow runs daily at 07:00 UTC in **reconcile** mode:
+
+- Runs `derive.sh --write` and checks `ip_map_branch.txt` +
+  `docker/scripts/demoLibrary.source` for any diff vs `master`. Diff
+  detection is scoped to those two files so unrelated edits to
+  `tools/auto-derive/` can't trip a bot PR.
+- On diff: force-pushes the stable branch `auto-derive/reconciliation` and
+  opens (or updates, if already open) a PR titled
+  `[auto-derive] reconcile demo_farm against upstream openemr master`.
+- On no diff: if a reconciliation PR is open from a prior run, closes it
+  and deletes the remote branch (upstream drift reverted).
+
+The branch is **stable + force-pushed**, so the bot updates the same PR
+across days rather than spamming new ones. Merge to land the reconciled
+state; the bot quiets until the next genuine drift.
+
+`workflow_dispatch` defaults to `reconcile` too; pick `dry-run` from the
+input dropdown to preview the algorithm's output without any branch/PR
+side effects (uploaded as the `derive-output` artifact).
+
+**Caveat:** the bot PR is created via `GITHUB_TOKEN`, so downstream
+workflows (rabbit, CI) don't run on it automatically. The fixture suite
+job in this same workflow is the authoritative algorithm validator. To
+manually re-trigger CI on the PR, push an empty commit:
+
+```sh
+git commit --allow-empty -m 'trigger ci' && git push
+```
+
 ## PR scope
 
-This is **PR #1** of the auto-derive workstream:
+The auto-derive workstream:
 
-- PR #1 (this): scaffold + dry-run output (artifact + step summary). No
-  live PR opening.
-- PR #2: add live PR opening on diff (peter-evans force-push pattern).
+- PR #1: scaffold + dry-run output (artifact + step summary). No live PR
+  opening.
+- PR #2 (this): write + auto-PR mode (force-push stable branch, open or
+  update PR on diff, close on no-diff).
 - PR #3: atomic flip -- wire `repository_dispatch` consumers + retire
   `.github/workflows/bump-tag.yml` + the `tools/release/` PHP toolchain.


### PR DESCRIPTION
## What

Promotes the `derive-ip-map` workflow from dry-run-only (PR #135) to active reconciliation:

- Daily 07:00 UTC schedule runs `derive.sh --write` and, on any diff in `ip_map_branch.txt` or `docker/scripts/demoLibrary.source` vs `master`, force-pushes the stable branch `auto-derive/reconciliation` and opens (or updates) a PR titled `[auto-derive] reconcile demo_farm against upstream openemr master`.
- On no-diff with an open reconciliation PR from a prior run: the PR is closed (with explanatory comment) and the remote branch deleted -- upstream drift reverted.
- `workflow_dispatch` now takes a `mode` input (`reconcile` default, `dry-run` optional). `dry-run` mode keeps the artifact-upload preview behavior from PR #135 with no branch/PR side effects.
- Fixture test suite job is unchanged from PR #135.

## Why

PR #135 set up the algorithm + dry-run scaffolding. PR #2 (this) is the "live" rung -- the bot now actually reconciles. PR #3 will retire the legacy `bump-tag.yml` + `tools/release/` PHP toolchain.

## Behavior details

- **Stable branch + force-push:** the bot updates the same PR across days rather than spamming new ones. `--force-with-lease` is safe even if the branch was just deleted (lease against missing ref).
- **Scoped diff:** detection is `git diff --quiet -- ip_map_branch.txt docker/scripts/demoLibrary.source`. An unrelated edit to `tools/auto-derive/` (or anywhere else) on master won't trip the bot into PR-ing changes it didn't make.
- **Scoped staging:** `git add` only the two output files. No accidental sweep of other working-tree noise.
- **Idempotent across midstream merges:** if a maintainer manually merges the bot PR while the next day's run is in flight, the next force-push to the (now-merged-and-typically-deleted) branch still works.
- **Repo guard:** the reconcile job's `if:` pins to `openemr/demo_farm_openemr` so forks don't accidentally try to open PRs against themselves.

## Caveats

- PRs created via `GITHUB_TOKEN` do NOT trigger downstream workflows (rabbit, CI). The in-workflow fixture suite job is the authoritative algorithm validator. To manually run CI on a bot PR, push an empty commit (`git commit --allow-empty -m 'trigger ci' && git push`).
- **Repo settings prereq:** _Settings -> Actions -> General -> Workflow permissions_ must have "Allow GitHub Actions to create and approve pull requests" enabled. Without this, the `gh pr create` step will fail.

## Out of scope

- `tools/auto-derive/derive.sh` (algorithm is stable from PR #135)
- `tools/auto-derive/fixtures-and-tests/**` (fixtures are stable from PR #135)
- `tools/release/**`, `demo_build.sh`, `ip_map_branch.txt`, `docker/scripts/demoLibrary.source` (untouched here; the daily bot run will pick up any drift)

## Test plan

- [ ] Confirm repo setting "Allow GitHub Actions to create and approve pull requests" is enabled on `openemr/demo_farm_openemr`
- [ ] Trigger `workflow_dispatch` with `mode=dry-run` -- verify artifact uploads, no branch created, no PR opened
- [ ] Trigger `workflow_dispatch` with `mode=reconcile` -- verify either (a) no-diff path logs cleanly with no PR, or (b) diff path creates branch `auto-derive/reconciliation` + opens PR with expected title/body/stat/full-diff
- [ ] Re-trigger `reconcile` with no underlying drift change -- verify existing PR is updated (gh pr edit) rather than duplicated
- [ ] If a bot PR is open, manually merge it, then re-trigger `reconcile` with no further drift -- verify clean no-diff exit with no zombie PR
- [ ] Fixture test job still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified “derive ip_map” workflow that can run on a daily schedule or via manual dispatch.
  * Supports selectable execution modes: reconcile (updates) and dry-run (no changes).
  * Automatically manages a reconciliation pull request—creating/updating it when changes are detected and closing it when none are found.
* **Documentation**
  * Updated the auto-derive usage guide for write-mode behavior.
  * Expanded workflow notes covering daily reconcile, diff detection scope, and how to run dry-run and CI manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->