### PR TITLE
ci(shellcheck): add shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,102 @@
+name: ShellCheck
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '**.sh'
+    - '**.source'
+    - '.github/workflows/shellcheck.yml'
+    - '.shellcheckrc'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - '**.sh'
+    - '**.source'
+    - '.github/workflows/shellcheck.yml'
+    - '.shellcheckrc'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v7
+    - name: Get changed shell files
+      id: changed-files
+      # We run shellcheck on all unique shell files in the repo
+      # if only the workflow file itself is changed in a PR.
+      # Thus we validate changes to the workflow file.
+      continue-on-error: true
+      uses: tj-actions/changed-files@v47
+      with:
+        files: |
+          **.sh
+          **.source
+    - name: Create unique files list
+      id: unique-files
+      run: |
+        set -x
+        # Create a temp directory to store file hashes
+        mkdir -p /tmp/shellcheck-hashes
+
+        # Initialize variable to hold unique files
+        unique_files=''
+
+        # If the changed-files step failed or returned empty,
+        # use git to find all shell files in the repo.
+        if [[ "${{ steps.changed-files.outcome }}" = success && "${{ steps.changed-files.outputs.any_changed }}" = true ]]; then
+          echo 'Changed files found, checking only those.'
+          set -f  # disable glob expansion
+          files_to_check=( ${{ steps.changed-files.outputs.all_changed_files }} )
+          set +f  # re-enable glob expansion
+        else
+          echo 'No changed files found, checking all shell files in the repo.'
+          # Use globstar to find shell files in subdirectories.
+          shopt -s globstar nullglob
+          files_to_check=(
+            **/*.sh
+            **/*.source
+          )
+        fi
+
+        unique_files=()
+        # Process each changed file
+        for file in "${files_to_check[@]}"; do
+          [[ -f "$file" ]] || continue
+          # Get hash of file content
+          hash=$(sha256sum "$file" | cut -d ' ' -f 1)
+          # Check if we've seen this hash before
+          [[ -f "/tmp/shellcheck-hashes/$hash" ]] && continue
+          # New unique file
+          touch "/tmp/shellcheck-hashes/$hash"
+          unique_files+=( "$file" )
+        done
+
+        # This relies on one space between each path name.
+        echo "files=${unique_files[*]}" >> "$GITHUB_OUTPUT"
+    - name: Run shellcheck on unique files
+      if: ${{ steps.unique-files.outputs.files != '' }}
+      # Pipefail is somehow only enabled when we explicitly
+      # specify the shell as bash, even though bash is the
+      # default shell.
+      shell: bash
+      run: |
+        shellcheck --check-sourced --external-sources --format=checkstyle ${{ steps.unique-files.outputs.files }} | tee checkstyle-shellcheck.xml
+    - uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+      if: ${{ failure() && hashFiles('checkstyle-shellcheck.xml') != '' }}
+      with:
+        files: checkstyle-shellcheck.xml
+        notices-as-warnings: true
+    - name: Upload shellcheck results
+      if: ${{ failure() && hashFiles('checkstyle-shellcheck.xml') != '' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: shellcheck-results
+        path: checkstyle-shellcheck.xml
+        if-no-files-found: error

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,4 @@
-name: ShellCheck
+name: ShellCheck (ratchet in progress)
 on:
   push:
     branches:
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   shellcheck:
-    name: ShellCheck
+    name: ShellCheck (ratchet in progress)
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,45 @@
+# ShellCheck configuration for demo_farm_openemr
+#
+# Scope: this file silences pre-existing violations across the repo so that
+# the ShellCheck workflow can be enabled without first rewriting every script.
+# Every silenced check below represents real cleanup work that should land in
+# follow-up PRs -- this file is a ratchet, not a permanent blessing. Once a
+# category of violations is fixed in the tree, the matching entry here should
+# be dropped so new occurrences get caught.
+#
+# Compare to the upstream openemr/openemr .shellcheckrc, which uses
+# `enable=all` and has no `disable=` lines because that codebase has been
+# cleaned up. This repo isn't there yet.
+
+external-sources=true
+
+# Pre-existing style/info notices. ShellCheck's `severity=warning` rc directive
+# is ignored when invoked with `--format=checkstyle` (the workflow's mode),
+# so we silence these by code instead of by severity.
+disable=SC1001  # `\=` is a regular `=` (1)
+disable=SC2001  # use bash substitution instead of sed (2)
+disable=SC2005  # useless echo (1)
+disable=SC2006  # use `$(...)` instead of backticks (88)
+disable=SC2016  # expressions don't expand in single quotes (5)
+disable=SC2086  # double quote to prevent globbing/word splitting (1255) -- bulk of repo noise
+disable=SC2129  # consider `{ cmd1; cmd2; } > file` (2)
+disable=SC2196  # `egrep` is non-standard (2)
+
+# Pre-existing POSIX-sh warnings, all emitted from demo_build.sh which carries
+# a stale `#!/bin/sh` shebang but uses bash features (arrays, `[[`, `==`)
+# throughout. The right fix is to switch the shebang to bash; until then,
+# ShellCheck flags every bashism as undefined-in-POSIX. (77 violations)
+disable=SC3014  # `==` in place of `=`
+disable=SC3028  # `RANDOM` undefined
+disable=SC3030  # arrays undefined
+disable=SC3037  # `echo` flags undefined
+disable=SC3054  # array references undefined
+
+# Pre-existing bash warnings deferred to follow-up cleanup PRs.
+disable=SC1090  # can't follow non-constant source (9 violations)
+disable=SC2034  # appears unused (7 violations)
+disable=SC2046  # quote to prevent word splitting (1 violation)
+disable=SC2048  # use `"${array[@]}"` with quotes (1 violation)
+disable=SC2115  # use `"${var:?}"` to guard `rm -rf` (3 violations) -- real footgun
+disable=SC2155  # declare and assign separately (4 violations) -- masks return values
+disable=SC2164  # `cd ... || exit` (25 violations)


### PR DESCRIPTION
## Why

Brings `demo_farm_openemr` to parity with `openemr/openemr`'s shellcheck workflow pattern. Catches new shell-script regressions on PR and push, with inline PR annotations and artifact upload of the checkstyle report.

## Scope

- `**.sh` and `**.source` files anywhere in the repo
- The workflow file and `.shellcheckrc` themselves (so changes to either re-trigger across all shell files)

Trimmed from openemr/openemr's pattern: that workflow tracks specific `contrib/util/...` and `docker/library/...` paths that don't exist here. Triggers are `push` and `pull_request` against `master` only (no `rel-*` branches in this repo).

## Strategy: Option A (infra now, real fixes later)

The existing repo carries ~125 warning-level violations and ~1350 style/info notices across `demo_build.sh`, `docker/scripts/`, and `tools/auto-derive/derive.sh`. Rewriting all of them in one PR would bury the workflow change.

This PR adds a `.shellcheckrc` that silences each pre-existing category by error code, with inline comments noting how many violations each line covers and what real bug class is being deferred. The file is documented as a **ratchet**: every silenced code represents follow-up cleanup work, and entries should be dropped as those PRs land so new occurrences get caught.

Categorized violations silenced (totals across all shell files):

**Pre-existing warning-level (125 total)**, all from `demo_build.sh` carrying a stale `#!/bin/sh` shebang while using bash features throughout:
- SC3037 echo flags (42), SC3014 `==`-vs-`=` (19), SC3030 arrays (11), SC3054 array refs (3), SC3028 `RANDOM` (2)
- SC2164 `cd` without `|| exit` (25)
- SC1090 dynamic source (9)
- SC2034 unused vars (7)
- SC2155 masked return values (4) -- **real bug class, deferred**
- SC2115 unguarded `rm -rf "$var/"` (3) -- **real footgun, deferred**
- SC2046, SC2048 (1 each)

**Pre-existing style/info-level (~1350 total)**, which `--format=checkstyle` includes despite `severity=warning` in rc (shellcheck quirk):
- SC2086 unquoted expansions (1255) -- bulk of repo noise
- SC2006 backtick command substitution (88)
- SC2016, SC2129, SC2196, SC2001, SC2005, SC1001 (small tails)

After `.shellcheckrc`: `shellcheck --check-sourced --external-sources --format=checkstyle **/*.sh **/*.source` returns exit 0 with zero error entries in the XML.

## Deferred to follow-up PRs

- Rewrite `demo_build.sh` properly: switch shebang to bash and clean up the SC2115 / SC2155 footguns. These are the highest-value cleanups.
- Quote-correctness pass for SC2086 across the repo.
- Modernize SC2006 backticks to `$(...)`.

Each PR should drop its corresponding `disable=` line from `.shellcheckrc`.

## Workflow choices

- Same actions and versions as openemr/openemr: `actions/checkout@v7`, `tj-actions/changed-files@v47`, `staabm/annotate-pull-request-from-checkstyle-action@v1`, `actions/upload-artifact@v7`.
- Same hash-based dedup pattern (handles identical content across `tools/auto-derive/fixtures-and-tests/fixtures/*/.../demoLibrary.source` copies efficiently).
- Same fallback: if only the workflow file itself changes, run against all shell files in the repo so workflow edits are validated.
- Same concurrency block (cancel-in-progress on PRs only).
- Runner: `ubuntu-24.04`.

## Test plan

- [ ] CI ShellCheck workflow runs on this PR and passes
- [ ] Workflow annotates inline on a future PR that introduces a real shellcheck violation (test in a follow-up cleanup PR)
- [ ] `tools/auto-derive/derive.sh` passes shellcheck (verified locally; only had 3 SC2034 unused-var warnings, now silenced)
- [ ] Local: `shellcheck --check-sourced --external-sources --format=checkstyle **/*.sh **/*.source` exits 0 with the committed `.shellcheckrc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated ShellCheck workflow that runs on pushes and pull requests affecting shell-related files.
  * Deduplicates checks to avoid re-running ShellCheck on identical file contents.
  * Annotates pull requests with ShellCheck findings when issues are detected.
  * Uploads ShellCheck results as an artifact for easier review.
* **Chores**
  * Added a repository `.shellcheckrc` to enable ShellCheck while temporarily allowing existing findings via targeted rule disables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->