### PR TITLE
fix(auto-derive): printf format starting with '-' breaks bash builtin

### DIFF
--- a/.github/workflows/derive-ip-map.yml
+++ b/.github/workflows/derive-ip-map.yml
@@ -192,8 +192,11 @@ jobs:
             printf '</details>\n\n'
             printf '## Behavior\n\n'
             printf 'This PR is **idempotent across daily runs**. If left unmerged, the bot will:\n'
-            printf '- Force-push fresh reconciliation tomorrow (if upstream state has drifted further)\n'
-            printf '- Close this PR automatically (if upstream reverts and the diff disappears)\n\n'
+            # The two bullet lines below MUST use `%s\n` form: bash's printf
+            # builtin parses a leading `-` in the format string as an option
+            # flag and aborts with "invalid option" -- breaking the entire job.
+            printf '%s\n' '- Force-push fresh reconciliation tomorrow (if upstream state has drifted further)'
+            printf '%s\n\n' '- Close this PR automatically (if upstream reverts and the diff disappears)'
             printf 'Merging will land the reconciled state and the bot will stop nagging until the next genuine drift.\n\n'
             printf '## CI note\n\n'
             printf 'This PR was created by `GITHUB_TOKEN`, so downstream workflows (rabbit, CI) do NOT run on it automatically. PR #135'"'"'s fixture suite is the authoritative validator for the algorithm; if you want to manually run CI here, push an empty commit.\n'


### PR DESCRIPTION
## Summary

Scheduled reconciliation broke today on its first non-empty-diff run with:

\`\`\`
/home/runner/work/_temp/.../sh: line 21: printf: - : invalid option
printf: usage: printf [-v var] format [arguments]
##[error]Process completed with exit code 2.
\`\`\`

Reproducer: https://github.com/openemr/demo_farm_openemr/actions/runs/28315987703

## Root cause

The reconcile job's \`Build PR body\` step has:

\`\`\`bash
printf '- Force-push fresh reconciliation tomorrow ...\n'
printf '- Close this PR automatically ...\n\n'
\`\`\`

Bash's \`printf\` builtin parses a leading \`-\` in the **format string** as an option flag attempt (\`-F\`, \`-o\`, etc.), and aborts with \"invalid option\" when the option isn't recognized. The string content is treated as the format, not as the value of a \`%s\`.

## Why it slipped past PR #138 review

Prior scheduled runs hit the no-diff early-exit path (workflow closes any open reconciliation PR and returns) before reaching the body-building step. Today's first run that found a real diff (the rel-704/rel-800/rel-810 col-3 deltas + 8.1.1 description bump) exercised the broken code path.

## Fix

Pass the bullet content as a \`%s\` value instead of as the format string:

\`\`\`bash
printf '%s\n' '- Force-push fresh reconciliation tomorrow ...'
printf '%s\n\n' '- Close this PR automatically ...'
\`\`\`

Added an inline comment explaining the trap so future edits don't reintroduce it.

## Audit

Grepped all \`printf\` calls in the workflow — only these 2 lines have format strings starting with \`-\`. Other printfs start with letters, backticks, or \`%\`, so no others triggered.

## Test plan

- [ ] CI passes
- [ ] Next scheduled run (or manual \`workflow_dispatch\` mode=reconcile) opens the reconciliation PR cleanly instead of failing in Build PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for the PR body’s Behavior section so bullet points render consistently.
  * Fixed an issue where leading dashes could be interpreted incorrectly and removed an extra trailing newline in the generated text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->