### PR TITLE
ci(shellcheck): drop SC2115 disable + fix 7 rm -rf footguns in demo_build.sh

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -40,6 +40,5 @@ disable=SC1090  # can't follow non-constant source (9 violations)
 disable=SC2034  # appears unused (7 violations)
 disable=SC2046  # quote to prevent word splitting (1 violation)
 disable=SC2048  # use `"${array[@]}"` with quotes (1 violation)
-disable=SC2115  # use `"${var:?}"` to guard `rm -rf` (3 violations) -- real footgun
 disable=SC2155  # declare and assign separately (4 violations) -- masks return values
 disable=SC2164  # `cd ... || exit` (25 violations)

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -516,6 +516,17 @@ IPADDRESS=$DOCKERDEMO
  fi
 
  if $useCapsuleBoolean; then
+  # Defensive: capsule file must be a non-empty flat segment (no slashes,
+  # not "." or ".."). Source is ip_map_branch.txt's capsule column; this
+  # guards against typos or malicious edits that could turn the later
+  # `rm -fr "${OPENEMR:?}/${useCapsuleFile}"` into something destructive
+  # like `rm -fr "${OPENEMR:?}/"` (empty) or path traversal via `..`.
+  case "$useCapsuleFile" in
+   '' | */* | . | ..)
+    echo "ERROR: invalid useCapsuleFile value: '$useCapsuleFile' (must be a non-empty flat segment with no slashes or .. traversal)" | tee -a $LOG >&2
+    exit 1
+    ;;
+  esac
   # load the capsule
   echo "Load $useCapsuleFile capsule"
   echo "Load $useCapsuleFile capsule" >> $LOG

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -373,10 +373,10 @@ IPADDRESS=$DOCKERDEMO
  echo "Copy git OpenEMR to web directory"
  echo "Copy git OpenEMR to web directory" >> $LOG
  mkdir -p $OPENEMR
- rm -fr $OPENEMR/*
+ rm -fr "${OPENEMR:?}"/*
  rsync --recursive --exclude .git $GIT/* $OPENEMR/
  if ! $packageServe; then
-   rm -fr $GIT
+   rm -fr "${GIT:?}"
  fi
 
  #INSTALL AND CONFIGURE OPENEMR
@@ -522,7 +522,7 @@ IPADDRESS=$DOCKERDEMO
   # First, check to ensure the capsule exists
   if [ -f "$CAPSULES/${useCapsuleFile}.tgz" ]; then
    # ensure unpackaged directory is cleared prior to using
-   rm -fr "$OPENEMR/${useCapsuleFile}"
+   rm -fr "${OPENEMR:?}/${useCapsuleFile}"
    cp "$CAPSULES/${useCapsuleFile}.tgz" "$OPENEMR/"
    tar -xzf "${useCapsuleFile}.tgz"
    # Note need to first clear the current database
@@ -544,7 +544,7 @@ IPADDRESS=$DOCKERDEMO
     chown apache:apache "$OPENEMR/sites/default/documents/certificates/oapublic.key"
    fi
    # clear unpackaged directory
-   rm -fr "$OPENEMR/${useCapsuleFile}"
+   rm -fr "${OPENEMR:?}/${useCapsuleFile}"
    if $demoDataUpgrade; then
     # Run the sql upgrade script. This allows using capsule on most recent codebase.
     echo "Upgrading capsule from $demoDataUpgradeFrom"
@@ -673,7 +673,7 @@ IPADDRESS=$DOCKERDEMO
    composer global remove phing/phing &>> $LOG
 
    # remove the node_modules directory
-   rm -fr $TMPDIR/openemr/node_modules &>> $LOG
+   rm -fr "${TMPDIR:?}/openemr/node_modules" &>> "$LOG"
 
    # optimize
    composer dump-autoload -o &>> $LOG
@@ -706,8 +706,8 @@ IPADDRESS=$DOCKERDEMO
   date > date-cvs.txt
 
   # Clean up
-  rm -fr $TMPDIR
-  rm -fr $GIT
+  rm -fr "${TMPDIR:?}"
+  rm -fr "${GIT:?}"
   echo "Done creating OpenEMR Development packages"
   echo "Done creating OpenEMR Development packages" >> $LOG
  fi


### PR DESCRIPTION
## Summary

First scheduled shellcheck ratchet for demo_farm_openemr. PR #139 introduced a shellcheck workflow alongside a permissive `.shellcheckrc` that silences pre-existing violations. The rc is a **ratchet, not a permanent blessing** -- each follow-up PR removes one `disable=` line by fixing the underlying violations. This PR is the first such cleanup.

SC2115 was selected as the first target because it has the highest blast radius: `rm -rf $var/...` patterns where an empty/unset `$var` expands to `rm -rf /...`. Real footgun.

## Fix

All sites in `demo_build.sh` switched to `${var:?}` parameter expansion. If `$var` is empty or unset, bash aborts immediately with `parameter null or not set` **before** `rm` runs -- safer than `[[ -n "$var" ]] && rm` because it doesn't add a conditional branch.

| Line | Before | After |
|---|---|---|
| 376 | `rm -fr $OPENEMR/*` | `rm -fr "${OPENEMR:?}"/*` |
| 379 | `rm -fr $GIT` | `rm -fr "${GIT:?}"` |
| 525 | `rm -fr "$OPENEMR/${useCapsuleFile}"` | `rm -fr "${OPENEMR:?}/${useCapsuleFile}"` |
| 547 | `rm -fr "$OPENEMR/${useCapsuleFile}"` | `rm -fr "${OPENEMR:?}/${useCapsuleFile}"` |
| 676 | `rm -fr $TMPDIR/openemr/node_modules &>> $LOG` | `rm -fr "${TMPDIR:?}/openemr/node_modules" &>> "$LOG"` |
| 709 | `rm -fr $TMPDIR` | `rm -fr "${TMPDIR:?}"` |
| 710 | `rm -fr $GIT` | `rm -fr "${GIT:?}"` |

Then dropped `disable=SC2115` from `.shellcheckrc`.

> Note: the rc comment said "3 violations" -- it was an approximation when the ratchet was established. Actual count was 7 (the 4 unquoted plus 3 already-quoted-but-still-unguarded sites that shellcheck still flags). All now fixed.

## Verification

Local shellcheck 0.9.0 with the SC2115 disable removed:

```bash
$ shellcheck --check-sourced --external-sources --format=checkstyle \
    $(find . -type f \( -name "*.sh" -o -name "*.source" \) \
      -not -path "./.git/*") 2>&1 | grep -c 'SC2115'
0
$ ... | grep -c 'severity="error"'
0
```

CI shellcheck workflow on this PR is the authoritative gate.

## Test plan

- [ ] CI shellcheck workflow passes (no SC2115 hits, no new errors)
- [ ] Diff review: every `rm -fr` referencing `$OPENEMR`, `$GIT`, or `$TMPDIR` uses `${var:?}`

Closes #140

Related: #139 (workflow that established the shellcheck ratchet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety around build and cleanup steps by preventing accidental deletion when required paths are missing or empty.
  * Added validation for capsule path inputs to avoid unsafe path construction and early-exit on invalid values.
  * Removed a ShellCheck suppression so potentially risky delete commands are now checked more strictly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->