### PR TITLE
feat(build-tests): add Phase 1 dry-run regression suite for demo_build.sh (#146)

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -1,0 +1,40 @@
+name: build-tests (dry-run)
+
+# Phase 1 of issue #146: per-PR regression coverage for demo_build.sh.
+#
+# Runs `demo_build.sh --dry-run` against each fixture in
+# tools/build-tests/fixtures/ and diffs the captured action log against
+# the golden. Catches the PR #142 / #145 class of bug (control-flow,
+# field-index, quoting) at PR time, in seconds rather than minutes.
+#
+# Phase 2 (separate PR, future) will add a slower nightly job that
+# actually executes the script end-to-end against a compose stack;
+# this fast job is the per-PR signal.
+#
+# Workflow path includes derive-ip-map.yml because the auto-derive bot
+# can land changes to demo_build.sh / ip_map_branch.txt — those should
+# trigger this suite too.
+
+on:
+  pull_request:
+    paths:
+      - demo_build.sh
+      - tools/build-tests/**
+      - .github/workflows/build-tests.yml
+  workflow_dispatch:
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run fixture test suite
+        run: |
+          set -euo pipefail
+          ./tools/build-tests/test.sh

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -10,10 +10,6 @@ name: build-tests (dry-run)
 # Phase 2 (separate PR, future) will add a slower nightly job that
 # actually executes the script end-to-end against a compose stack;
 # this fast job is the per-PR signal.
-#
-# Workflow path includes derive-ip-map.yml because the auto-derive bot
-# can land changes to demo_build.sh / ip_map_branch.txt — those should
-# trigger this suite too.
 
 on:
   pull_request:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -33,6 +33,8 @@ disable=SC3014  # `==` in place of `=`
 disable=SC3028  # `RANDOM` undefined
 disable=SC3030  # arrays undefined
 disable=SC3037  # `echo` flags undefined
+disable=SC3043  # `local` undefined -- used by the build-tests helpers added in #146
+disable=SC3050  # `printf %q` undefined -- used by the build-tests action-log emitter (#146)
 disable=SC3054  # array references undefined
 
 # Pre-existing bash warnings deferred to follow-up cleanup PRs.

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -53,6 +53,21 @@ unset _arg
 
 ACTION_LOG="${ACTION_LOG:-/dev/null}"
 
+# _emit_action_log -- internal: read a single line from stdin, redact
+# common credential patterns, append to ACTION_LOG. Best-effort: covers
+# the two credential shapes this script currently emits (mariadb -p<pass>
+# from $rpassparam and rootpass=<pass> from $mrp). Phase 2's live-run
+# work will need to extend this (composer github auth tokens, Authorization
+# headers) — for Phase 1 dry-run those values are stubbed to placeholders
+# before reaching the log, so they don't need redaction yet. Do not treat
+# ACTION_LOG as safe for production debugging without further review.
+_emit_action_log () {
+  sed -E \
+    -e 's/(-p)[^[:space:]\\]+/\1<REDACTED>/g' \
+    -e 's/(rootpass=)[^[:space:]\\]+/\1<REDACTED>/g' \
+    >> "$ACTION_LOG"
+}
+
 # run_action <cmd> <arg>... -- argv form. Log a normalized ACTION line, then
 # execute the command in live mode or skip in dry-run. Use for commands
 # without shell metacharacters (no pipes, no redirects).
@@ -61,7 +76,7 @@ run_action () {
     printf 'ACTION:'
     printf ' %q' "$@"
     printf '\n'
-  } >> "$ACTION_LOG"
+  } | _emit_action_log
   if ! $dryRun; then
     "$@"
   fi
@@ -70,8 +85,16 @@ run_action () {
 # run_action_sh <shell-command-string> -- shell form. Log ACTION_SH, then
 # eval the string. Use for commands with pipes, redirects, or compound
 # logic; variable expansion happens at the call site via double-quoting.
+#
+# Trust assumption: the wrapped string is built from script-internal
+# variables whose values originate in ip_map_branch.txt and the demo-farm
+# docker env (DOCKERDEMO, DOCKERMYSQLHOST, etc.) -- not from user input.
+# This script is not designed to safely process attacker-controlled values
+# in those vars; production callers must ensure ip_map_branch.txt is
+# authored by trusted operators and env vars come from the demo-farm
+# infrastructure.
 run_action_sh () {
-  printf 'ACTION_SH: %s\n' "$1" >> "$ACTION_LOG"
+  printf 'ACTION_SH: %s\n' "$1" | _emit_action_log
   if ! $dryRun; then
     eval "$1"
   fi
@@ -91,7 +114,7 @@ run_action_capture () {
     printf 'ACTION_CAPTURE:'
     printf ' %q' "$@"
     printf '\n'
-  } >> "$ACTION_LOG"
+  } | _emit_action_log
   if $dryRun; then
     printf '%s\n' "$_stub"
   else
@@ -740,8 +763,11 @@ IPADDRESS=$DOCKERDEMO
   echo "Creating OpenEMR Development packages"
   echo "Creating OpenEMR Development packages" >> $LOG
 
-  # Prepare the development package
-  run_action mkdir -p $TMPDIR/openemr
+  # Prepare the development package. mkdir is intentionally unwrapped:
+  # subsequent `cd $TMPDIR/openemr` needs the directory to exist even in
+  # dry-run, where the rsync below is skipped. Matches the same pattern
+  # used for $WEB/log and $OPENEMR earlier in the script.
+  mkdir -p $TMPDIR/openemr
   run_action_sh "rsync --recursive --exclude .git $GIT/* $TMPDIR/openemr/"
   #Build openemr package
   if [ ! -d $TMPDIR/openemr/vendor ]; then
@@ -789,8 +815,10 @@ IPADDRESS=$DOCKERDEMO
    run_action chmod a+w $TMPDIR/openemr/interface/modules/zend_modules/config/application.config.php
   fi
 
-  # Create the web file directory
-  run_action mkdir $FILESSERVEDIR
+  # Create the web file directory. Unwrapped: subsequent `cd $FILESSERVEDIR`
+  # needs the dir to exist in dry-run, where the tar/zip/md5sum writes
+  # below are all skipped.
+  mkdir $FILESSERVEDIR
 
   # Save the tar.gz cvs package
   cd $TMPDIR

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -9,13 +9,105 @@
 #This script is for the OpenEMR demo farms
 #
 
+# === BUILD-TIME TESTING SUPPORT (issue #146) ===============================
+# Parse CLI args + set up the action-log emitter that --dry-run mode and the
+# fixture-test harness in tools/build-tests/ depend on. None of this is
+# load-bearing for production execution: with no flags and no ACTION_LOG env
+# var, the helpers degrade to "echo nothing, then exec the command" -- i.e.,
+# behave like the previous direct invocations.
+#
+# Args:
+#   --dry-run            Skip side-effecting commands (composer, npm,
+#                        mariadb, apk, curl, httpd, postfix, stunnel,
+#                        system-path writes). Pure parsing/branching
+#                        still runs. Used by tools/build-tests/.
+#   <subdemoName>        Optional positional. If present, run a light
+#                        reset of just that subdemo (preserves existing
+#                        legacy behavior).
+#
+# Env-var overrides (defaulted to production paths; only set in tests):
+#   ACTION_LOG           File path to append ACTION lines to. Default
+#                        /dev/null in production -- emitter is a no-op
+#                        when not under test.
+#   WEB, webUser, GITMAIN, GITDEMOFARM, CAPSULES, OPENEMRTMPDIR
+#                        Override hardcoded paths for fixture isolation
+#                        (see "PATH VARIABLES" block below).
+
+dryRun=false
+lightReset=false
+lightResetDemo=""
+for _arg in "$@"; do
+  case "$_arg" in
+    --dry-run) dryRun=true ;;
+    --*)
+      echo "Unknown flag: $_arg" >&2
+      exit 2
+      ;;
+    *)
+      lightReset=true
+      lightResetDemo="$_arg"
+      ;;
+  esac
+done
+unset _arg
+
+ACTION_LOG="${ACTION_LOG:-/dev/null}"
+
+# run_action <cmd> <arg>... -- argv form. Log a normalized ACTION line, then
+# execute the command in live mode or skip in dry-run. Use for commands
+# without shell metacharacters (no pipes, no redirects).
+run_action () {
+  {
+    printf 'ACTION:'
+    printf ' %q' "$@"
+    printf '\n'
+  } >> "$ACTION_LOG"
+  if ! $dryRun; then
+    "$@"
+  fi
+}
+
+# run_action_sh <shell-command-string> -- shell form. Log ACTION_SH, then
+# eval the string. Use for commands with pipes, redirects, or compound
+# logic; variable expansion happens at the call site via double-quoting.
+run_action_sh () {
+  printf 'ACTION_SH: %s\n' "$1" >> "$ACTION_LOG"
+  if ! $dryRun; then
+    eval "$1"
+  fi
+}
+
+# run_action_capture [--stub <value>] <cmd> <arg>... -- log + execute (live)
+# or log + emit <value> on stdout (dry-run). Use when the script captures
+# command output into a variable: $(run_action_capture ...). The stub keeps
+# downstream parsing (jq, conditionals) sane in dry-run mode.
+run_action_capture () {
+  local _stub=""
+  if [ "$1" = "--stub" ]; then
+    _stub="$2"
+    shift 2
+  fi
+  {
+    printf 'ACTION_CAPTURE:'
+    printf ' %q' "$@"
+    printf '\n'
+  } >> "$ACTION_LOG"
+  if $dryRun; then
+    printf '%s\n' "$_stub"
+  else
+    "$@"
+  fi
+}
+# === END BUILD-TIME TESTING SUPPORT ========================================
+
 # Install demo-farm-specific runtime dependencies that the flex base image
 # doesn't bundle. apk add is idempotent — if already installed (e.g., on a
 # restartSubdemo re-invocation inside a running container) this is a fast
 # no-op rather than an error.
-apk add --no-cache postfix stunnel
+run_action apk add --no-cache postfix stunnel
 
 getRandomThemeOne () {
+    if $dryRun; then echo '<RANDOM_THEME_1>'; return; fi
     THEME[0]='style_ash_blue.css'
     THEME[1]='style_burgundy.css'
     THEME[2]='style_cadmium_yellow.css'
@@ -60,6 +152,7 @@ getRandomThemeOne () {
 }
 
 getRandomThemeTwo () {
+    if $dryRun; then echo '<RANDOM_THEME_2>'; return; fi
     THEME[0]='style_cobalt_blue.css'
     THEME[1]='style_forest_green.css'
     THEME[2]='style_light.css'
@@ -79,21 +172,16 @@ collect_var () {
    echo `grep -i "^[[:space:]]*$1[[:space:]=]" $2 | cut -d \= -f 2 | cut -d \; -f 1 | sed "s/[ 	'\"]//gi"`
 }
 
-# If there is a parameter, then just pursue a light reset of the subdemo
-if [ -z "$1" ]; then
- lightReset=false;
-else
- lightReset=true;
- lightResetDemo=$1
-fi
+# (lightReset / lightResetDemo are now set by the unified arg parser at the
+# top of the script; the legacy "$1" check used to live here.)
 
 # PATH VARIABLES AND CREATED NEEDED DIRS
 # Demo farm runs every cluster on the flex (Alpine) base image as of #116,
 # so the web root is always Alpine's /var/www/localhost/htdocs.
-WEB=/var/www/localhost/htdocs
+WEB="${WEB:-/var/www/localhost/htdocs}"
 # Web server user: alpine images use 'apache'. Used when dropping privileges
 # to run OpenEMR CLI scripts (RootCliGuard in openemr#12267 refuses root).
-webUser=apache
+webUser="${webUser:-apache}"
 LOG=$WEB/log/logSetup.txt
 mkdir -p $WEB/log
 
@@ -106,10 +194,10 @@ mkdir -p $WEB/log
 # PHP_VERSION_ABBR is set by the flex image (e.g. "85" for PHP 8.5).
 echo "start log" > $WEB/log/logPhp.txt
 chmod 666 $WEB/log/logPhp.txt
-echo "error_log = $WEB/log/logPhp.txt" > /etc/php${PHP_VERSION_ABBR}/conf.d/99-demo-farm-error-log.ini
-CAPSULES=/home/openemr/capsules
-GITMAIN=/home/openemr/git
-GITDEMOFARM=$GITMAIN/demo_farm_openemr
+run_action_sh "echo 'error_log = $WEB/log/logPhp.txt' > /etc/php${PHP_VERSION_ABBR}/conf.d/99-demo-farm-error-log.ini"
+CAPSULES="${CAPSULES:-/home/openemr/capsules}"
+GITMAIN="${GITMAIN:-/home/openemr/git}"
+GITDEMOFARM="${GITDEMOFARM:-$GITMAIN/demo_farm_openemr}"
 # Strip '#' comment lines from ip_map_branch.txt up front so every
 # downstream `grep "$IPADDRESS" | cut -f N` lookup ignores them. The
 # file uses commented section headers (Production / UP FOR GRABS /
@@ -120,7 +208,10 @@ grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"
 PASSWORDRESETSCRIPT=$GITDEMOFARM/set_pass.php
 OPENEMRAPACHECONF=$GITDEMOFARM/openemr-alpine.conf
 GITTRANS=$GITMAIN/translations_development_openemr
-TMPDIR=/tmp/openemr-tmp
+# OPENEMRTMPDIR (vs TMPDIR(1), used implicitly by mktemp et al.) overrides
+# the staging directory for the openemr CVS package built in the packageServe
+# branch. Production default matches pre-refactor behavior.
+TMPDIR="${OPENEMRTMPDIR:-/tmp/openemr-tmp}"
 
 if $lightReset; then
  echo "This is a light reset"
@@ -363,7 +454,7 @@ IPADDRESS=$DOCKERDEMO
   cd $GITMAIN
   # `--branch <ref>` accepts both branch names and tag names; combined with
   # `--depth 1` this gives a shallow clone of the exact ref.
-  git clone --branch "$GITBRANCH" --depth 1 "$OPENEMRREPO"
+  run_action git clone --branch "$GITBRANCH" --depth 1 "$OPENEMRREPO"
  else
   echo "ERROR, The OpenEMR git repository already exist"
   echo "ERROR, The OpenEMR git repository already exist" >> $LOG
@@ -373,10 +464,10 @@ IPADDRESS=$DOCKERDEMO
  echo "Copy git OpenEMR to web directory"
  echo "Copy git OpenEMR to web directory" >> $LOG
  mkdir -p $OPENEMR
- rm -fr "${OPENEMR:?}"/*
- rsync --recursive --exclude .git $GIT/* $OPENEMR/
+ run_action_sh "rm -fr \"${OPENEMR:?}\"/*"
+ run_action_sh "rsync --recursive --exclude .git $GIT/* $OPENEMR/"
  if ! $packageServe; then
-   rm -fr "${GIT:?}"
+   run_action rm -fr "${GIT:?}"
  fi
 
  #INSTALL AND CONFIGURE OPENEMR
@@ -384,12 +475,12 @@ IPADDRESS=$DOCKERDEMO
  echo "Configuring OpenEMR" >> $LOG
  #
  # Set file and directory permissions
- chmod 666 $OPENEMR/sites/default/sqlconf.php
- chmod -R a+w $OPENEMR/sites/default/documents
+ run_action chmod 666 $OPENEMR/sites/default/sqlconf.php
+ run_action chmod -R a+w $OPENEMR/sites/default/documents
 
  if [ -f $OPENEMR/interface/modules/zend_modules/config/application.config.php ] ; then
   # This is specifically for Zend code that is currently under development, so it works on the demos.
-  chmod a+w $OPENEMR/interface/modules/zend_modules/config/application.config.php
+  run_action chmod a+w $OPENEMR/interface/modules/zend_modules/config/application.config.php
   echo "Configuring Zend file permission: application.config.php"
   echo "Configuring Zend file permission: application.config.php" >> $LOG
  fi
@@ -398,44 +489,46 @@ IPADDRESS=$DOCKERDEMO
  if [ ! -d $OPENEMR/vendor ]; then
   cd $OPENEMR
 
-  # install php dependencies
-  GITHUB_KEY_COMPOSER=`cat /home/openemr/github-key`
-  githubTokenRateLimitRequest=`curl -H "Authorization: token $GITHUB_KEY_COMPOSER" https://api.github.com/rate_limit`
+  # install php dependencies. In dry-run we stub a fake key and a rate-limit
+  # of 0 so the "Not using composer github api token" branch is exercised
+  # deterministically (the other branch would log the real github key).
+  GITHUB_KEY_COMPOSER=$(run_action_capture --stub '<DRY_RUN_GITHUB_KEY>' cat /home/openemr/github-key)
+  githubTokenRateLimitRequest=$(run_action_capture --stub '{"rate":{"remaining":0}}' curl -H "Authorization: token $GITHUB_KEY_COMPOSER" https://api.github.com/rate_limit)
   githubTokenRateLimit=`echo $githubTokenRateLimitRequest | jq '.rate.remaining'`
   echo "Number of github api requests remaining is $githubTokenRateLimit"
   echo "Number of github api requests remaining is $githubTokenRateLimit" >> $LOG
   if [ "$githubTokenRateLimit" -gt 1000 ]; then
    echo "Using composer github api token"
    echo "Using composer github api token" >> $LOG
-   composer config --global --auth github-oauth.github.com $GITHUB_KEY_COMPOSER
+   run_action composer config --global --auth github-oauth.github.com $GITHUB_KEY_COMPOSER
   else
    echo "Not using composer github api token"
    echo "Not using composer github api token" >> $LOG
   fi
-  composer install --no-dev &>> $LOG
+  run_action_sh "composer install --no-dev &>> $LOG"
 
   if [ -f $OPENEMR/package.json ]; then
    # install frontend dependencies (need unsafe-perm to run as root)
-   npm install --unsafe-perm &>> $LOG
+   run_action_sh "npm install --unsafe-perm &>> $LOG"
    # build css
-   npm run build &>> $LOG
+   run_action_sh "npm run build &>> $LOG"
   fi
 
   if [ -f $OPENEMR/ccdaservice/package.json ]; then
    # install ccdaservice dependencies (need unsafe-perm to run as root)
    cd $OPENEMR/ccdaservice
-   npm install --unsafe-perm &>> $LOG
+   run_action_sh "npm install --unsafe-perm &>> $LOG"
    cd $OPENEMR
   fi
 
   # clean up
-  composer global require phing/phing &>> $LOG
-  /root/.composer/vendor/bin/phing vendor-clean &>> $LOG
-  /root/.composer/vendor/bin/phing assets-clean &>> $LOG
-  composer global remove phing/phing &>> $LOG
+  run_action_sh "composer global require phing/phing &>> $LOG"
+  run_action_sh "/root/.composer/vendor/bin/phing vendor-clean &>> $LOG"
+  run_action_sh "/root/.composer/vendor/bin/phing assets-clean &>> $LOG"
+  run_action_sh "composer global remove phing/phing &>> $LOG"
 
   # optimize
-  composer dump-autoload -o &>> $LOG
+  run_action_sh "composer dump-autoload -o &>> $LOG"
  fi
 
  #
@@ -447,28 +540,28 @@ IPADDRESS=$DOCKERDEMO
  export OPENEMR_ENABLE_INSTALLER_AUTO=1
  INST=$OPENEMR/contrib/util/installScripts/InstallerAuto.php
  INSTTEMP=$OPENEMR/contrib/util/installScripts/InstallerAutoTemp.php
- sed -e 's@^exit;@ @' <$INST >$INSTTEMP
+ run_action_sh "sed -e 's@^exit;@ @' <$INST >$INSTTEMP"
  DOCKERPARAMETERS="server=${DOCKERMYSQLHOST} loginhost=% login=${DOCKERDEMO} pass=${DOCKERDEMO} dbname=${DOCKERDEMO}"
- 
+
  # Drop privileges to the web user: RootCliGuard refuses root for the Installer class (openemr#12267).
  if $translationsDevelopment ; then
   echo "Using online development translation set"
   echo "Using online development translation set" >> $LOG
   if [ -z "$mrp" ] ; then
-   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP development_translations=yes $DOCKERPARAMETERS" >> $LOG
+   run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $INSTTEMP development_translations=yes $DOCKERPARAMETERS\" >> $LOG"
   else
-   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP development_translations=yes rootpass=$mrp $DOCKERPARAMETERS" >> $LOG
+   run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $INSTTEMP development_translations=yes rootpass=$mrp $DOCKERPARAMETERS\" >> $LOG"
   fi
  else
   echo "Using included translation set"
   echo "Using included translation set" >> $LOG
   if [ -z "$mrp" ] ; then
-   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP $DOCKERPARAMETERS" >> $LOG
+   run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $INSTTEMP $DOCKERPARAMETERS\" >> $LOG"
   else
-   su -p -s /bin/sh "$webUser" -c "php -f $INSTTEMP rootpass=$mrp $DOCKERPARAMETERS" >> $LOG
+   run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $INSTTEMP rootpass=$mrp $DOCKERPARAMETERS\" >> $LOG"
   fi
  fi
- rm -f $INSTTEMP
+ run_action rm -f $INSTTEMP
 
  if $demoData; then
   # Need to insert the demo data, which is in $dd item in the pieces directory
@@ -478,8 +571,8 @@ IPADDRESS=$DOCKERDEMO
   if [ -f "$GITDEMOFARM/pieces/$dd" ]; then
     # Now insert the data
     #  -Note need to first clear the current database (can make this an option in future if need to add data without clearing database)
-    mariadb-dump --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam --add-drop-table --no-data $DOCKERDEMO | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO
-    mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO < "$GITDEMOFARM/pieces/$dd"
+    run_action_sh "mariadb-dump --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam --add-drop-table --no-data $DOCKERDEMO | grep ^DROP | awk ' BEGIN { print \"SET FOREIGN_KEY_CHECKS=0;\" } { print \$0 } END { print \"SET FOREIGN_KEY_CHECKS=1;\" } ' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO"
+    run_action_sh "mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO < \"$GITDEMOFARM/pieces/$dd\""
     echo "Completed inserting demo data from $dd"
     echo "Completed inserting demo data from $dd" >> $LOG
   else
@@ -490,19 +583,19 @@ IPADDRESS=$DOCKERDEMO
    # Run the sql upgrade script. This allows using demo data on most recent codebase.
    echo "Upgrading demo data from $demoDataUpgradeFrom"
    echo "Upgrading demo data from $demoDataUpgradeFrom" >> $LOG
-   sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php
-   sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${demoDataUpgradeFrom}';@" $OPENEMR/sql_upgrade_temp.php
-   sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" $OPENEMR/sql_upgrade_temp.php
+   run_action_sh "sed -e \"s@!empty(\\\$_POST\\['form_submit'\\])@true@\" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php"
+   run_action_sh "sed -i \"s@\\\$form_old_version = \\\$_POST\\['form_old_version'\\];@\\\$form_old_version = '${demoDataUpgradeFrom}';@\" $OPENEMR/sql_upgrade_temp.php"
+   run_action_sh "sed -i \"1s@^@<?php \\\$_GET['site'] = 'default'; ?>@\" $OPENEMR/sql_upgrade_temp.php"
    # Drop privileges to the web user: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-   su -p -s /bin/sh "$webUser" -c "php -f $OPENEMR/sql_upgrade_temp.php" >> $LOG
-   rm -f $OPENEMR/sql_upgrade_temp.php
+   run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $OPENEMR/sql_upgrade_temp.php\" >> $LOG"
+   run_action rm -f $OPENEMR/sql_upgrade_temp.php
    # Also need to change encoding/collation when using OpenEMR versions at 6 or greater
    VERSION_MAJOR=$(collect_var \$v_major $OPENEMR/version.php)
    if [ -n "$VERSION_MAJOR" ] && [ "$VERSION_MAJOR" -ge "6" ]; then
     echo "Upgrading database/collation to utf8mbf since using version ${VERSION_MAJOR}"
     echo "Upgrading database/collation to utf8mbf since using version ${VERSION_MAJOR}" >> $LOG
-     mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${DOCKERDEMO}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam
-     mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${DOCKERDEMO}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam
+     run_action_sh "mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e 'SELECT concat(\"ALTER DATABASE \`\",TABLE_SCHEMA,\"\` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;\") as _sql FROM \`information_schema\`.\`TABLES\` where \`TABLE_SCHEMA\` like \"'\"${DOCKERDEMO}\"'\" and \`TABLE_TYPE\`=\"BASE TABLE\" group by \`TABLE_SCHEMA\`;' | egrep '^ALTER' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam"
+     run_action_sh "mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e 'SELECT concat(\"ALTER TABLE \`\",TABLE_SCHEMA,\"\`.\`\",TABLE_NAME,\"\` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;\") as _sql FROM \`information_schema\`.\`TABLES\` where \`TABLE_SCHEMA\` like \"'\"${DOCKERDEMO}\"'\" and \`TABLE_TYPE\`=\"BASE TABLE\" group by \`TABLE_SCHEMA\`, \`TABLE_NAME\`;' | egrep '^ALTER' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam"
    fi
   fi
   if $translationsDevelopment ; then
@@ -533,39 +626,39 @@ IPADDRESS=$DOCKERDEMO
   # First, check to ensure the capsule exists
   if [ -f "$CAPSULES/${useCapsuleFile}.tgz" ]; then
    # ensure unpackaged directory is cleared prior to using
-   rm -fr "${OPENEMR:?}/${useCapsuleFile}"
-   cp "$CAPSULES/${useCapsuleFile}.tgz" "$OPENEMR/"
-   tar -xzf "${useCapsuleFile}.tgz"
+   run_action rm -fr "${OPENEMR:?}/${useCapsuleFile}"
+   run_action cp "$CAPSULES/${useCapsuleFile}.tgz" "$OPENEMR/"
+   run_action tar -xzf "${useCapsuleFile}.tgz"
    # Note need to first clear the current database
-   mariadb-dump --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam --add-drop-table --no-data $DOCKERDEMO | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO
-   mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO < "$OPENEMR/${useCapsuleFile}/backup.sql"
-   cp "$OPENEMR/sites/default/sqlconf.php" "$OPENEMR/"
-   rsync --delete --recursive --links "$OPENEMR/${useCapsuleFile}/sites" "$OPENEMR/"
-   cp "$OPENEMR/sqlconf.php" "$OPENEMR/sites/default/sqlconf.php"
-   rm "$OPENEMR/sqlconf.php"
-   chmod -R a+w $OPENEMR/sites/default/documents
+   run_action_sh "mariadb-dump --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam --add-drop-table --no-data $DOCKERDEMO | grep ^DROP | awk ' BEGIN { print \"SET FOREIGN_KEY_CHECKS=0;\" } { print \$0 } END { print \"SET FOREIGN_KEY_CHECKS=1;\" } ' | mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO"
+   run_action_sh "mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam $DOCKERDEMO < \"$OPENEMR/${useCapsuleFile}/backup.sql\""
+   run_action cp "$OPENEMR/sites/default/sqlconf.php" "$OPENEMR/"
+   run_action rsync --delete --recursive --links "$OPENEMR/${useCapsuleFile}/sites" "$OPENEMR/"
+   run_action cp "$OPENEMR/sqlconf.php" "$OPENEMR/sites/default/sqlconf.php"
+   run_action rm "$OPENEMR/sqlconf.php"
+   run_action chmod -R a+w $OPENEMR/sites/default/documents
    if [ -f "$OPENEMR/sites/default/documents/certificates/oaprivate.key" ]; then
     # this file needs special treatment in the alpine demo dockers to work correctly
-    chmod 640 "$OPENEMR/sites/default/documents/certificates/oaprivate.key"
-    chown apache:apache "$OPENEMR/sites/default/documents/certificates/oaprivate.key"
+    run_action chmod 640 "$OPENEMR/sites/default/documents/certificates/oaprivate.key"
+    run_action chown apache:apache "$OPENEMR/sites/default/documents/certificates/oaprivate.key"
    fi
    if [ -f "$OPENEMR/sites/default/documents/certificates/oapublic.key" ]; then
     # this file needs special treatment in the alpine demo dockers to work correctly
-    chmod 660 "$OPENEMR/sites/default/documents/certificates/oapublic.key"
-    chown apache:apache "$OPENEMR/sites/default/documents/certificates/oapublic.key"
+    run_action chmod 660 "$OPENEMR/sites/default/documents/certificates/oapublic.key"
+    run_action chown apache:apache "$OPENEMR/sites/default/documents/certificates/oapublic.key"
    fi
    # clear unpackaged directory
-   rm -fr "${OPENEMR:?}/${useCapsuleFile}"
+   run_action rm -fr "${OPENEMR:?}/${useCapsuleFile}"
    if $demoDataUpgrade; then
     # Run the sql upgrade script. This allows using capsule on most recent codebase.
     echo "Upgrading capsule from $demoDataUpgradeFrom"
     echo "Upgrading capsule from $demoDataUpgradeFrom" >> $LOG
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${demoDataUpgradeFrom}';@" $OPENEMR/sql_upgrade_temp.php
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" $OPENEMR/sql_upgrade_temp.php
+    run_action_sh "sed -e \"s@!empty(\\\$_POST\\['form_submit'\\])@true@\" <$OPENEMR/sql_upgrade.php >$OPENEMR/sql_upgrade_temp.php"
+    run_action_sh "sed -i \"s@\\\$form_old_version = \\\$_POST\\['form_old_version'\\];@\\\$form_old_version = '${demoDataUpgradeFrom}';@\" $OPENEMR/sql_upgrade_temp.php"
+    run_action_sh "sed -i \"1s@^@<?php \\\$_GET['site'] = 'default'; ?>@\" $OPENEMR/sql_upgrade_temp.php"
     # Drop privileges to the web user: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    su -p -s /bin/sh "$webUser" -c "php -f $OPENEMR/sql_upgrade_temp.php" >> $LOG
-    rm -f $OPENEMR/sql_upgrade_temp.php
+    run_action_sh "su -p -s /bin/sh \"$webUser\" -c \"php -f $OPENEMR/sql_upgrade_temp.php\" >> $LOG"
+    run_action rm -f $OPENEMR/sql_upgrade_temp.php
    fi
   else
    echo "ERROR: $useCapsuleFile capsule did not exist, so could not use"
@@ -575,7 +668,7 @@ IPADDRESS=$DOCKERDEMO
 
  #set up external link in global
  EXTERNALLINKBASE=$(echo "$EXTERNALLINK" | cut -d '/' -f 1)
- mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e "UPDATE ${DOCKERDEMO}.globals SET gl_value='https://${EXTERNALLINKBASE}' WHERE gl_name='site_addr_oath'"
+ run_action mariadb --skip-ssl -h "$DOCKERMYSQLHOST" -u root $rpassparam -e "UPDATE ${DOCKERDEMO}.globals SET gl_value='https://${EXTERNALLINKBASE}' WHERE gl_name='site_addr_oath'"
 
  #random theme generator
  if $randomTheme; then
@@ -591,7 +684,7 @@ IPADDRESS=$DOCKERDEMO
   echo -n "random theme is " >> $LOG
   echo "$RANDOM_THEME" >> $LOG
   #set the random theme
-  mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e "UPDATE ${DOCKERDEMO}.globals SET gl_value='${RANDOM_THEME}' WHERE gl_name='css_header'"
+  run_action mariadb --skip-ssl -h "$DOCKERMYSQLHOST" -u root $rpassparam -e "UPDATE ${DOCKERDEMO}.globals SET gl_value='${RANDOM_THEME}' WHERE gl_name='css_header'"
  fi
 
  # Enable patient portal + REST/FHIR/OAuth APIs for demos with the
@@ -599,7 +692,7 @@ IPADDRESS=$DOCKERDEMO
  if [ "$ppapi" = "1" ]; then
   echo "Setting up patient portal and API globals"
   echo "Setting up patient portal and API globals" >> $LOG
-  mariadb --skip-ssl -h $DOCKERMYSQLHOST -u root $rpassparam -e "
+  run_action mariadb --skip-ssl -h "$DOCKERMYSQLHOST" -u root $rpassparam -e "
     UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='portal_onsite_two_enable';
     UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_api';
     UPDATE ${DOCKERDEMO}.globals SET gl_value='1' WHERE gl_name='rest_fhir_api';
@@ -611,13 +704,13 @@ IPADDRESS=$DOCKERDEMO
  fi
 
  #reinstitute file permissions
- chmod 644 $OPENEMR/sites/default/sqlconf.php
+ run_action chmod 644 $OPENEMR/sites/default/sqlconf.php
  echo "Done configuring OpenEMR"
  echo "Done configuring OpenEMR" >> $LOG
 
  # Set up to allow demo and testing of hl7 labs feature
- mkdir $OPENEMR/sites/default/procedure_results
- chmod -R a+w $OPENEMR/sites/default/procedure_results
+ run_action mkdir $OPENEMR/sites/default/procedure_results
+ run_action chmod -R a+w $OPENEMR/sites/default/procedure_results
 
  # Set up swagger api to work
  if [ -f $OPENEMR/swagger/openemr-api.yaml ]; then
@@ -628,15 +721,15 @@ IPADDRESS=$DOCKERDEMO
   else
     demoPath="/${demo}"
   fi
-  sed -i "s@/apis/default/@${demoPath}/openemr/apis/default/@" $OPENEMR/swagger/openemr-api.yaml
-  sed -i "s@/oauth2/default/authorize@${demoPath}/openemr/oauth2/default/authorize@" $OPENEMR/swagger/openemr-api.yaml
-  sed -i "s@/oauth2/default/token@${demoPath}/openemr/oauth2/default/token@" $OPENEMR/swagger/openemr-api.yaml
+  run_action sed -i "s@/apis/default/@${demoPath}/openemr/apis/default/@" $OPENEMR/swagger/openemr-api.yaml
+  run_action sed -i "s@/oauth2/default/authorize@${demoPath}/openemr/oauth2/default/authorize@" $OPENEMR/swagger/openemr-api.yaml
+  run_action sed -i "s@/oauth2/default/token@${demoPath}/openemr/oauth2/default/token@" $OPENEMR/swagger/openemr-api.yaml
  fi
 
  #Security stuff
  #1. remove the library/openflashchart/php-ofc-library/ofc_upload_image.php file if it exists
  if [ -f $OPENEMR/library/openflashchart/php-ofc-library/ofc_upload_image.php ]; then
-  rm -f $OPENEMR/library/openflashchart/php-ofc-library/ofc_upload_image.php
+  run_action rm -f $OPENEMR/library/openflashchart/php-ofc-library/ofc_upload_image.php
   echo "Removed ofc_upload_image.php file"
   echo "Removed ofc_upload_image.php file" >> $LOG
  fi
@@ -648,77 +741,77 @@ IPADDRESS=$DOCKERDEMO
   echo "Creating OpenEMR Development packages" >> $LOG
 
   # Prepare the development package
-  mkdir -p $TMPDIR/openemr
-  rsync --recursive --exclude .git $GIT/* $TMPDIR/openemr/
+  run_action mkdir -p $TMPDIR/openemr
+  run_action_sh "rsync --recursive --exclude .git $GIT/* $TMPDIR/openemr/"
   #Build openemr package
   if [ ! -d $TMPDIR/openemr/vendor ]; then
    cd $TMPDIR/openemr
 
-   # install php dependencies
-   GITHUB_KEY_COMPOSER=`cat /home/openemr/github-key`
-   githubTokenRateLimitRequestPackage=`curl -H "Authorization: token $GITHUB_KEY_COMPOSER" https://api.github.com/rate_limit`
+   # install php dependencies (see twin block above for the dry-run stub rationale)
+   GITHUB_KEY_COMPOSER=$(run_action_capture --stub '<DRY_RUN_GITHUB_KEY>' cat /home/openemr/github-key)
+   githubTokenRateLimitRequestPackage=$(run_action_capture --stub '{"rate":{"remaining":0}}' curl -H "Authorization: token $GITHUB_KEY_COMPOSER" https://api.github.com/rate_limit)
    githubTokenRateLimitPackage=`echo $githubTokenRateLimitRequestPackage | jq '.rate.remaining'`
    echo "Number of github api requests remaining is $githubTokenRateLimitPackage"
    echo "Number of github api requests remaining is $githubTokenRateLimitPackage" >> $LOG
    if [ "$githubTokenRateLimitPackage" -gt 1000 ]; then
     echo "Using composer github api token"
     echo "Using composer github api token" >> $LOG
-    composer config --global --auth github-oauth.github.com $GITHUB_KEY_COMPOSER
+    run_action composer config --global --auth github-oauth.github.com $GITHUB_KEY_COMPOSER
    else
     echo "Not using composer github api token"
     echo "Not using composer github api token" >> $LOG
    fi
-   composer install --no-dev &>> $LOG
+   run_action_sh "composer install --no-dev &>> $LOG"
 
    if [ -f $TMPDIR/openemr/package.json ]; then
     # install frontend dependencies (need unsafe-perm to run as root)
-    npm install --unsafe-perm &>> $LOG
+    run_action_sh "npm install --unsafe-perm &>> $LOG"
     # build css
-    npm run build &>> $LOG
+    run_action_sh "npm run build &>> $LOG"
    fi
 
    # clean up
-   composer global require phing/phing &>> $LOG
-   /root/.composer/vendor/bin/phing vendor-clean &>> $LOG
-   /root/.composer/vendor/bin/phing assets-clean &>> $LOG
-   composer global remove phing/phing &>> $LOG
+   run_action_sh "composer global require phing/phing &>> $LOG"
+   run_action_sh "/root/.composer/vendor/bin/phing vendor-clean &>> $LOG"
+   run_action_sh "/root/.composer/vendor/bin/phing assets-clean &>> $LOG"
+   run_action_sh "composer global remove phing/phing &>> $LOG"
 
    # remove the node_modules directory
-   rm -fr "${TMPDIR:?}/openemr/node_modules" &>> "$LOG"
+   run_action_sh "rm -fr \"${TMPDIR:?}/openemr/node_modules\" &>> \"$LOG\""
 
    # optimize
-   composer dump-autoload -o &>> $LOG
+   run_action_sh "composer dump-autoload -o &>> $LOG"
   fi
-  chmod    a+w $TMPDIR/openemr/sites/default/sqlconf.php
-  chmod -R a+w $TMPDIR/openemr/sites/default/documents
+  run_action chmod a+w $TMPDIR/openemr/sites/default/sqlconf.php
+  run_action chmod -R a+w $TMPDIR/openemr/sites/default/documents
   if [ -f $TMPDIR/openemr/interface/modules/zend_modules/config/application.config.php ] ; then
    # This is specifically for Zend code that is currently under development(added in version 4.1.3).
-   chmod   a+w $TMPDIR/openemr/interface/modules/zend_modules/config/application.config.php
+   run_action chmod a+w $TMPDIR/openemr/interface/modules/zend_modules/config/application.config.php
   fi
 
   # Create the web file directory
-  mkdir $FILESSERVEDIR
+  run_action mkdir $FILESSERVEDIR
 
   # Save the tar.gz cvs package
   cd $TMPDIR
-  rm -f $FILESSERVEDIR/openemr-cvs.tar.gz
-  tar -czf $FILESSERVEDIR/openemr-cvs.tar.gz openemr
+  run_action rm -f $FILESSERVEDIR/openemr-cvs.tar.gz
+  run_action tar -czf $FILESSERVEDIR/openemr-cvs.tar.gz openemr
   cd $FILESSERVEDIR
-  md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt
+  run_action_sh "md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt"
 
   # Save the .zip cvs package
   cd $TMPDIR
-  rm -f $FILESSERVEDIR/openemr-cvs.zip
-  zip -rq $FILESSERVEDIR/openemr-cvs.zip openemr
+  run_action rm -f $FILESSERVEDIR/openemr-cvs.zip
+  run_action zip -rq $FILESSERVEDIR/openemr-cvs.zip openemr
   cd $FILESSERVEDIR
-  md5sum openemr-cvs.zip > openemr-windows-md5.txt
+  run_action_sh "md5sum openemr-cvs.zip > openemr-windows-md5.txt"
 
   # Create the time stamp
-  date > date-cvs.txt
+  run_action_sh "date > date-cvs.txt"
 
   # Clean up
-  rm -fr "${TMPDIR:?}"
-  rm -fr "${GIT:?}"
+  run_action rm -fr "${TMPDIR:?}"
+  run_action rm -fr "${GIT:?}"
   echo "Done creating OpenEMR Development packages"
   echo "Done creating OpenEMR Development packages" >> $LOG
  fi
@@ -731,14 +824,14 @@ done
 
 # Start Postfix for restarts, uses stunnel to communicate to aws ses email server.
 if ! $lightReset; then
-  stunnel /etc/stunnel/stunnel.conf >> $LOG
-  postfix start >> $LOG
+  run_action_sh "stunnel /etc/stunnel/stunnel.conf >> $LOG"
+  run_action_sh "postfix start >> $LOG"
 fi
 
 #restart apache and secure sensitive directories
 if ! $lightReset; then
- cp $OPENEMRAPACHECONF /etc/apache2/conf.d/openemr.conf
- httpd -k start >> $LOG
+ run_action cp $OPENEMRAPACHECONF /etc/apache2/conf.d/openemr.conf
+ run_action_sh "httpd -k start >> $LOG"
 fi
 
 echo "Demo install script is complete"
@@ -754,5 +847,5 @@ echo "$timeEnd" >> $LOG
 if ! $lightReset; then
   # to stop docker image from exiting
   echo "hold docker open"
-  tail -F -n0 /etc/hosts
+  run_action tail -F -n0 /etc/hosts
 fi

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -55,12 +55,17 @@ ACTION_LOG="${ACTION_LOG:-/dev/null}"
 
 # _emit_action_log -- internal: read a single line from stdin, redact
 # common credential patterns, append to ACTION_LOG. Best-effort: covers
-# the two credential shapes this script currently emits (mariadb -p<pass>
-# from $rpassparam and rootpass=<pass> from $mrp). Phase 2's live-run
-# work will need to extend this (composer github auth tokens, Authorization
-# headers) — for Phase 1 dry-run those values are stubbed to placeholders
-# before reaching the log, so they don't need redaction yet. Do not treat
-# ACTION_LOG as safe for production debugging without further review.
+# every credential shape this script currently emits:
+#   - mariadb `-p<pass>` from $rpassparam
+#   - InstallerAuto `rootpass=<pass>` from $mrp
+#   - curl `Authorization: token <github-key>` (rate_limit probe)
+#   - composer config `--auth github-oauth.github.com <github-key>`
+# In Phase 1 dry-run the github-key values are stubbed to placeholders
+# (<DRY_RUN_GITHUB_KEY>) which the `[A-Za-z0-9_]+` body match doesn't
+# touch (the `<>` get %q-escaped to `\<\>`). In Phase 2 live runs with
+# a real /home/openemr/github-key mounted, the raw token would otherwise
+# land in ACTION_LOG — the Authorization / --auth patterns prevent that.
+# ACTION_LOG should still be reviewed before being enabled in production.
 _emit_action_log () {
   # Anchor the `-p` pattern to start-of-line OR preceded by whitespace
   # so it only matches the standalone mariadb `-p<password>` flag and
@@ -68,6 +73,8 @@ _emit_action_log () {
   sed -E \
     -e 's/(^|[[:space:]])(-p)[^[:space:]\\]+/\1\2<REDACTED>/g' \
     -e 's/(rootpass=)[^[:space:]\\]+/\1<REDACTED>/g' \
+    -e 's/(Authorization:\\ token\\ )[A-Za-z0-9_]+/\1<REDACTED>/g' \
+    -e 's/(--auth\\ github-oauth\.github\.com\\ )[A-Za-z0-9_]+/\1<REDACTED>/g' \
     >> "$ACTION_LOG"
 }
 

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -62,8 +62,11 @@ ACTION_LOG="${ACTION_LOG:-/dev/null}"
 # before reaching the log, so they don't need redaction yet. Do not treat
 # ACTION_LOG as safe for production debugging without further review.
 _emit_action_log () {
+  # Anchor the `-p` pattern to start-of-line OR preceded by whitespace
+  # so it only matches the standalone mariadb `-p<password>` flag and
+  # not the embedded `-p` inside longer flags like `--unsafe-perm`.
   sed -E \
-    -e 's/(-p)[^[:space:]\\]+/\1<REDACTED>/g' \
+    -e 's/(^|[[:space:]])(-p)[^[:space:]\\]+/\1\2<REDACTED>/g' \
     -e 's/(rootpass=)[^[:space:]\\]+/\1<REDACTED>/g' \
     >> "$ACTION_LOG"
 }

--- a/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
+++ b/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
@@ -9,20 +9,20 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=hey server=mysql loginhost=% login=two pass=two dbname=two" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=<REDACTED> server=mysql loginhost=% login=two pass=two dbname=two" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two.globals\ SET\ gl_value=\'\<RANDOM_THEME_2\>\'\ WHERE\ gl_name=\'css_header\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ two.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ two.globals\ SET\ gl_value=\'\<RANDOM_THEME_2\>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results

--- a/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
+++ b/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
@@ -9,9 +9,9 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
+++ b/tools/build-tests/fixtures/branch-pinned-master/expected/action-log.txt
@@ -1,0 +1,37 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=hey server=mysql loginhost=% login=two pass=two dbname=two" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two.globals\ SET\ gl_value=\'\<RANDOM_THEME_2\>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> <WORK>/web/log/logSetup.txt
+ACTION_SH: postfix start >> <WORK>/web/log/logSetup.txt
+ACTION: cp <WORK>/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> <WORK>/web/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/branch-pinned-master/inputs.env
+++ b/tools/build-tests/fixtures/branch-pinned-master/inputs.env
@@ -1,0 +1,7 @@
+# Scenario: branch-pinned (master) cluster with development translations,
+# patient-portal/API globals, and random theme (funStuff=2 -> ThemeTwo).
+# Exercises: git clone --branch master, translationsDevelopment branch,
+# random theme branch, ppapi globals branch.
+DOCKERDEMO=two
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/branch-pinned-master/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/branch-pinned-master/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+two	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io	hey	0	0	2	0	0	Branch-pinned master demo (with udt, ppapi, random theme)

--- a/tools/build-tests/fixtures/capsule-path-traversal/expected/fail.txt
+++ b/tools/build-tests/fixtures/capsule-path-traversal/expected/fail.txt
@@ -1,0 +1,1 @@
+invalid useCapsuleFile value

--- a/tools/build-tests/fixtures/capsule-path-traversal/inputs.env
+++ b/tools/build-tests/fixtures/capsule-path-traversal/inputs.env
@@ -1,0 +1,11 @@
+# Scenario: useCapsuleFile column carries "../etc" (path-traversal attempt).
+# The case statement guard added by PR #145 (demo_build.sh lines ~617-622)
+# must reject this with a non-zero exit. Without the guard, the later
+# `rm -fr "${OPENEMR:?}/${useCapsuleFile}"` and `cp $CAPSULES/${useCapsuleFile}.tgz`
+# would traverse outside $OPENEMR.
+#
+# This is a fail-expected fixture (expected/fail.txt instead of action-log.txt):
+# the test asserts exit != 0 AND a specific error substring in script output.
+DOCKERDEMO=malcap
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/capsule-path-traversal/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/capsule-path-traversal/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+malcap	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	malcap.openemr.io	hey	0	0	0	0	../etc	Synthetic row exercising the useCapsuleFile path-traversal guard

--- a/tools/build-tests/fixtures/light-reset/expected/action-log.txt
+++ b/tools/build-tests/fixtures/light-reset/expected/action-log.txt
@@ -9,9 +9,9 @@ ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/light-reset/expected/action-log.txt
+++ b/tools/build-tests/fixtures/light-reset/expected/action-log.txt
@@ -9,19 +9,19 @@ ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/a/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=hey server=mysql loginhost=% login=two_a pass=two_a dbname=two_a" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=<REDACTED> server=mysql loginhost=% login=two_a pass=two_a dbname=two_a" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two_a.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ two_a.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/a/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/a/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/procedure_results

--- a/tools/build-tests/fixtures/light-reset/expected/action-log.txt
+++ b/tools/build-tests/fixtures/light-reset/expected/action-log.txt
@@ -1,0 +1,31 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/a/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/a/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/a/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/a/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=hey server=mysql loginhost=% login=two_a pass=two_a dbname=two_a" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ two_a.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/a/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/a/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/a/openemr/apis/default/@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/a/openemr/oauth2/default/authorize@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/a/openemr/oauth2/default/token@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/a/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php

--- a/tools/build-tests/fixtures/light-reset/inputs.env
+++ b/tools/build-tests/fixtures/light-reset/inputs.env
@@ -1,0 +1,9 @@
+# Scenario: light-reset of a single subdemo. The positional arg "a"
+# triggers lightReset=true; the script processes ONLY that subdemo and
+# skips the post-loop stunnel/postfix/cp/httpd/tail block. DOCKERDEMO=two
+# is the cluster's original; combined with subdemo "a" the actual lookup
+# key becomes "two_a" (per the script's $DOCKERDEMOORIGINAL_$demo logic).
+DOCKERDEMO=two
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85
+EXTRA_ARGS=a

--- a/tools/build-tests/fixtures/light-reset/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/light-reset/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+two_a	https://github.com/openemr/openemr.git	master	0	1	0	0	0	0	1	two.openemr.io/a	hey	0	0	0	0	0	Light-reset target subdemo

--- a/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
+++ b/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
@@ -9,9 +9,9 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
@@ -38,9 +38,9 @@ ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
@@ -67,9 +67,9 @@ ACTION: chmod -R a+w <WORK>/web/b/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
+++ b/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
@@ -9,19 +9,19 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven pass=seven dbname=seven" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=seven pass=seven dbname=seven" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ seven.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
@@ -38,19 +38,19 @@ ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/a/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven_a pass=seven_a dbname=seven_a" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=seven_a pass=seven_a dbname=seven_a" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven_a.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ seven_a.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/a/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/a/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/procedure_results
@@ -67,19 +67,19 @@ ACTION: chmod -R a+w <WORK>/web/b/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/b/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven_b pass=seven_b dbname=seven_b" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=seven_b pass=seven_b dbname=seven_b" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven_b.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ seven_b.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/b/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/b/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/b/openemr/sites/default/procedure_results

--- a/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
+++ b/tools/build-tests/fixtures/multi-demo/expected/action-log.txt
@@ -1,0 +1,94 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven pass=seven dbname=seven" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/a/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/a/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/a/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/a/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven_a pass=seven_a dbname=seven_a" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/a/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven_a.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/a/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/a/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/a/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/a/openemr/apis/default/@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/a/openemr/oauth2/default/authorize@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/a/openemr/oauth2/default/token@ <WORK>/web/a/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/a/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/b/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/b/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/b/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/b/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/b/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=seven_b pass=seven_b dbname=seven_b" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/b/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ seven_b.globals\ SET\ gl_value=\'https://seven.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE seven_b.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE seven_b.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/b/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/b/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/b/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/b/openemr/apis/default/@ <WORK>/web/b/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/b/openemr/oauth2/default/authorize@ <WORK>/web/b/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/b/openemr/oauth2/default/token@ <WORK>/web/b/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/b/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> <WORK>/web/log/logSetup.txt
+ACTION_SH: postfix start >> <WORK>/web/log/logSetup.txt
+ACTION: cp <WORK>/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> <WORK>/web/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/multi-demo/inputs.env
+++ b/tools/build-tests/fixtures/multi-demo/inputs.env
@@ -1,0 +1,9 @@
+# Scenario: multi-demo (DOCKERNUMBERDEMOS=3) iteration over ("empty","a","b").
+# Exercises the demosGo loop, the empty-vs-subdemo path branching
+# ($OPENEMR=$WEB/openemr vs $WEB/$demo/openemr; DOCKERDEMO=$DOCKERDEMOORIGINAL
+# vs ${DOCKERDEMOORIGINAL}_${demo}), and the per-iteration ip_map row
+# lookup. seven_b is synthetic (production currently has only seven, seven_a).
+DOCKERDEMO=seven
+DOCKERMYSQLHOST=mysql
+DOCKERNUMBERDEMOS=3
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/multi-demo/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/multi-demo/ip_map_branch.txt
@@ -1,0 +1,4 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+seven	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	seven.openemr.io	hey	0	0	0	0	0	Multi-demo iteration 1 (empty)
+seven_a	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	seven.openemr.io/a	hey	0	0	0	0	0	Multi-demo iteration 2 (a)
+seven_b	https://github.com/openemr/openemr.git	master	0	0	0	0	0	0	1	seven.openemr.io/b	hey	0	0	0	0	0	Multi-demo iteration 3 (b)

--- a/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
+++ b/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
@@ -1,0 +1,58 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch v7_0_4 --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/openemr/
+ACTION: chmod 666 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=six pass=six dbname=six" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ six.globals\ SET\ gl_value=\'https://six.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION: mkdir -p <WORK>/tmp/openemr
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/tmp/openemr/
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: rm -fr "<WORK>/tmp/openemr/node_modules" &>> "<WORK>/web/log/logSetup.txt"
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION: chmod a+w <WORK>/tmp/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/tmp/openemr/sites/default/documents
+ACTION: mkdir <WORK>/web/files
+ACTION: rm -f <WORK>/web/files/openemr-cvs.tar.gz
+ACTION: tar -czf <WORK>/web/files/openemr-cvs.tar.gz openemr
+ACTION_SH: md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt
+ACTION: rm -f <WORK>/web/files/openemr-cvs.zip
+ACTION: zip -rq <WORK>/web/files/openemr-cvs.zip openemr
+ACTION_SH: md5sum openemr-cvs.zip > openemr-windows-md5.txt
+ACTION_SH: date > date-cvs.txt
+ACTION: rm -fr <WORK>/tmp
+ACTION: rm -fr <WORK>/git/openemr
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> <WORK>/web/log/logSetup.txt
+ACTION_SH: postfix start >> <WORK>/web/log/logSetup.txt
+ACTION: cp <WORK>/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> <WORK>/web/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
+++ b/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
@@ -8,9 +8,9 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
+++ b/tools/build-tests/fixtures/release-packageserve/expected/action-log.txt
@@ -8,19 +8,19 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=six pass=six dbname=six" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=six pass=six dbname=six" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ six.globals\ SET\ gl_value=\'https://six.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ six.globals\ SET\ gl_value=\'https://six.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
@@ -28,7 +28,6 @@ ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagg
 ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
 ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
 ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
-ACTION: mkdir -p <WORK>/tmp/openemr
 ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/tmp/openemr/
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
@@ -41,7 +40,6 @@ ACTION_SH: rm -fr "<WORK>/tmp/openemr/node_modules" &>> "<WORK>/web/log/logSetup
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION: chmod a+w <WORK>/tmp/openemr/sites/default/sqlconf.php
 ACTION: chmod -R a+w <WORK>/tmp/openemr/sites/default/documents
-ACTION: mkdir <WORK>/web/files
 ACTION: rm -f <WORK>/web/files/openemr-cvs.tar.gz
 ACTION: tar -czf <WORK>/web/files/openemr-cvs.tar.gz openemr
 ACTION_SH: md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt

--- a/tools/build-tests/fixtures/release-packageserve/inputs.env
+++ b/tools/build-tests/fixtures/release-packageserve/inputs.env
@@ -1,0 +1,9 @@
+# Scenario: tag-pinned release demo with serve_packages=1. Exercises the
+# entire ~80-line packageServe branch (line 726+ in demo_build.sh), which
+# is otherwise untouched by other scenarios: a second composer install +
+# npm install + npm run build + phing + dump-autoload in the staging dir,
+# tar/zip/md5sum packaging, $GIT cleanup. No demo data, no random theme,
+# no ppapi -- minimal "what does packageServe alone produce" coverage.
+DOCKERDEMO=six
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/release-packageserve/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/release-packageserve/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+six	https://github.com/openemr/openemr.git	v7_0_4	0	0	1	0	0	0	1	six.openemr.io	hey	0	0	0	0	0	Release demo (v7_0_4) with serve_packages=1 (exercises packageServe block)

--- a/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
@@ -1,0 +1,46 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch v8_0_0_3 --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=five pass=five dbname=five" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -phey --add-drop-table --no-data five | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -phey five
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey five < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
+ACTION_SH: sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <<WORK>/web/openemr/sql_upgrade.php ><WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '5.0.0';@" <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/sql_upgrade_temp.php" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ five.globals\ SET\ gl_value=\'https://demo.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ five.globals\ SET\ gl_value=\'\<RANDOM_THEME_1\>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> <WORK>/web/log/logSetup.txt
+ACTION_SH: postfix start >> <WORK>/web/log/logSetup.txt
+ACTION: cp <WORK>/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> <WORK>/web/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
@@ -9,9 +9,9 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/expected/action-log.txt
@@ -9,29 +9,29 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=five pass=five dbname=five" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=five pass=five dbname=five" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -phey --add-drop-table --no-data five | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -phey five
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey five < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
+ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -p<REDACTED> --add-drop-table --no-data five | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -p<REDACTED> five
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> five < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
 ACTION_SH: sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <<WORK>/web/openemr/sql_upgrade.php ><WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '5.0.0';@" <WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" <WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/sql_upgrade_temp.php" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/sql_upgrade_temp.php
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ five.globals\ SET\ gl_value=\'https://demo.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ five.globals\ SET\ gl_value=\'\<RANDOM_THEME_1\>\'\ WHERE\ gl_name=\'css_header\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -p<REDACTED>
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -p<REDACTED>
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ five.globals\ SET\ gl_value=\'https://demo.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ five.globals\ SET\ gl_value=\'\<RANDOM_THEME_1\>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results

--- a/tools/build-tests/fixtures/tag-pinned-with-data/inputs.env
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/inputs.env
@@ -1,0 +1,8 @@
+# Scenario: tag-pinned (v8_0_0_3) cluster with demo data + demo-data-upgrade
+# + random theme (funStuff=4 -> ThemeOne, since not "2"). Exercises:
+# git clone --branch <tag>, demoData branch, demoDataUpgrade branch
+# including sed transforms + utf8mb4 ALTERs (gated on $v_major >= 6),
+# random theme branch, ppapi globals branch.
+DOCKERDEMO=five
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/tag-pinned-with-data/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+five	https://github.com/openemr/openemr.git	v8_0_0_3	0	0	0	0	demo_5_0_0_5.sql	0	1	demo.openemr.io	hey	0	5.0.0	4	0	0	Tag-pinned production demo with demo data, upgrade, and random theme

--- a/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
+++ b/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
@@ -9,28 +9,28 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=four_a pass=four_a dbname=four_a" >> <WORK>/web/log/logSetup.txt
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=mysql loginhost=% login=four_a pass=four_a dbname=four_a" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
-ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -phey --add-drop-table --no-data four_a | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -phey four_a
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey four_a < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
+ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -p<REDACTED> --add-drop-table --no-data four_a | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -p<REDACTED> four_a
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> four_a < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
 ACTION_SH: sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <<WORK>/web/openemr/sql_upgrade.php ><WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '5.0.0';@" <WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" <WORK>/web/openemr/sql_upgrade_temp.php
 ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/sql_upgrade_temp.php" >> <WORK>/web/log/logSetup.txt
 ACTION: rm -f <WORK>/web/openemr/sql_upgrade_temp.php
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
-ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ four_a.globals\ SET\ gl_value=\'https://four.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
-ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -p<REDACTED>
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -p<REDACTED>
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e UPDATE\ four_a.globals\ SET\ gl_value=\'https://four.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -p<REDACTED> -e $'\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
 ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
 ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
 ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results

--- a/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
+++ b/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
@@ -9,9 +9,9 @@ ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
 ACTION_CAPTURE: cat /home/openemr/github-key
 ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
 ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
-ACTION_SH: npm install --unsafe-p<REDACTED> &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
 ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt

--- a/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
+++ b/tools/build-tests/fixtures/up-for-grabs-fork/expected/action-log.txt
@@ -1,0 +1,45 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = <WORK>/web/log/logPhp.txt' > /etc/php85/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch calendar-twig-migration --depth 1 https://github.com/juggernautsei/openemr.git
+ACTION_SH: rm -fr "<WORK>/web/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git <WORK>/git/openemr/* <WORK>/web/openemr/
+ACTION: rm -fr <WORK>/git/openemr
+ACTION: chmod 666 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/documents
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\ \<DRY_RUN_GITHUB_KEY\> https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm run build &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> <WORK>/web/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' <<WORK>/web/openemr/contrib/util/installScripts/InstallerAuto.php ><WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=hey server=mysql loginhost=% login=four_a pass=four_a dbname=four_a" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: mariadb-dump --skip-ssl -h mysql -u root -phey --add-drop-table --no-data four_a | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h mysql -u root -phey four_a
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey four_a < "<WORK>/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
+ACTION_SH: sed -e "s@!empty(\$_POST\['form_submit'\])@true@" <<WORK>/web/openemr/sql_upgrade.php ><WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '5.0.0';@" <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: su -p -s /bin/sh "root" -c "php -f <WORK>/web/openemr/sql_upgrade_temp.php" >> <WORK>/web/log/logSetup.txt
+ACTION: rm -f <WORK>/web/openemr/sql_upgrade_temp.php
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
+ACTION_SH: mariadb --skip-ssl -h mysql -u root -phey -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"four_a"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h mysql -u root -phey
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e UPDATE\ four_a.globals\ SET\ gl_value=\'https://four.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h mysql -u root -phey -e $'\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE four_a.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE four_a.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 <WORK>/web/openemr/sites/default/sqlconf.php
+ACTION: mkdir <WORK>/web/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w <WORK>/web/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ <WORK>/web/openemr/swagger/openemr-api.yaml
+ACTION: rm -f <WORK>/web/openemr/library/openflashchart/php-ofc-library/ofc_upload_image.php
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> <WORK>/web/log/logSetup.txt
+ACTION_SH: postfix start >> <WORK>/web/log/logSetup.txt
+ACTION: cp <WORK>/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> <WORK>/web/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/up-for-grabs-fork/inputs.env
+++ b/tools/build-tests/fixtures/up-for-grabs-fork/inputs.env
@@ -1,0 +1,8 @@
+# Scenario: up-for-grabs cluster pointing at a community fork. Exercises
+# the path where OPENEMRREPO is NOT openemr/openemr (juggernautsei here)
+# and the branch is a non-canonical feature branch (calendar-twig-migration).
+# The action log proves the script clones the fork URL + branch verbatim
+# rather than overriding to canonical.
+DOCKERDEMO=four_a
+DOCKERMYSQLHOST=mysql
+PHP_VERSION_ABBR=85

--- a/tools/build-tests/fixtures/up-for-grabs-fork/ip_map_branch.txt
+++ b/tools/build-tests/fixtures/up-for-grabs-fork/ip_map_branch.txt
@@ -1,0 +1,2 @@
+docker_number	openemr_repo	branch	serve_development_translations(not used)	use_development_translations	serve_packages	legacy_patching(not used)	demo_data	demo_ssh(not used)	patient_portals_and_api	external_link	root_sql_pass	branch_tag(not used)	demo_data_upgrade_from	fun_stuff	pass_reset	capsule	description
+four_a	https://github.com/juggernautsei/openemr.git	calendar-twig-migration	0	0	0	0	demo_5_0_0_5.sql	0	1	four.openemr.io/a	hey	0	5.0.0	0	0	0	Up-for-grabs fork demo (non-canonical URL + branch + demo data)

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -17,9 +17,11 @@
 #                                   "two" and "two_a" rows).
 #   extra/                       -- (optional) tree of files copied OVER
 #                                   the kitchen-sink work tree post-setup,
-#                                   mirroring its layout. Use for
-#                                   per-scenario marker contents:
-#                                     extra/openemr/version.php           (sets $v_major)
+#                                   mirroring its layout (the work tree
+#                                   places openemr at $WEB/openemr, so
+#                                   fixture overrides need the web/ prefix).
+#                                   Use for per-scenario marker contents:
+#                                     extra/web/openemr/version.php       (sets $v_major)
 #                                     extra/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql
 #                                     extra/capsules/<name>.tgz
 #   expected/action-log.txt      -- the golden, with $WORK paths replaced

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# test.sh -- run demo_build.sh --dry-run against each fixture, diff vs
+# the golden action log. Exit 0 iff every fixture matches its golden.
+#
+# Each fixture directory contains:
+#   inputs.env                   -- env vars sourced before the run.
+#                                   Required: DOCKERDEMO.
+#                                   Optional: DOCKERMYSQLHOST,
+#                                   DOCKERNUMBERDEMOS, PHP_VERSION_ABBR,
+#                                   EXTRA_ARGS (appended after --dry-run).
+#   ip_map_branch.txt            -- the ip_map subset the script will read.
+#                                   Should contain ONLY the row(s) needed
+#                                   for this scenario to avoid the
+#                                   grep "$IPADDRESS" substring-match
+#                                   ambiguity (e.g., "two" matches both
+#                                   "two" and "two_a" rows).
+#   extra/                       -- (optional) tree of files copied OVER
+#                                   the kitchen-sink work tree post-setup,
+#                                   mirroring its layout. Use for
+#                                   per-scenario marker contents:
+#                                     extra/openemr/version.php           (sets $v_major)
+#                                     extra/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql
+#                                     extra/capsules/<name>.tgz
+#   expected/action-log.txt      -- the golden, with $WORK paths replaced
+#                                   by the literal token <WORK>.
+#
+# To regenerate a fixture's golden after intentional changes to
+# demo_build.sh, run:
+#   UPDATE_GOLDENS=1 ./tools/build-tests/test.sh
+# and review the diff before committing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEMO_BUILD="$REPO_ROOT/demo_build.sh"
+FIXTURES_DIR="$SCRIPT_DIR/fixtures"
+UPDATE_GOLDENS="${UPDATE_GOLDENS:-0}"
+
+if [[ ! -x "$DEMO_BUILD" ]]; then
+    chmod +x "$DEMO_BUILD" 2>/dev/null || true
+fi
+
+# Per-fixture work dirs are tracked here and cleaned up at script exit.
+# NOTE: an earlier draft used `trap ... RETURN` inside run_one_fixture(),
+# but bash fires RETURN on `source` too -- so sourcing the fixture's
+# inputs.env triggered the trap mid-setup and nuked the work dir.
+WORK_DIRS=()
+# shellcheck disable=SC2317  # invoked via the EXIT trap below
+cleanup_work_dirs () {
+    local w
+    for w in "${WORK_DIRS[@]}"; do
+        rm -rf "$w"
+    done
+}
+trap cleanup_work_dirs EXIT
+
+# Stand up a kitchen-sink work tree for a single fixture run. Layout
+# mirrors what demo_build.sh expects at production paths. Marker files
+# are empty unless the fixture's extra/ tree provides content (e.g.,
+# version.php's $v_major drives a real branch in the script).
+#
+# Marker files are seeded both under the main $WEB/openemr/ (== $OPENEMR
+# when demo="empty") AND under $WEB/<letter>/openemr/ for letters a..i so
+# multi-demo fixtures (DOCKERNUMBERDEMOS=N up to 10) get the same gated
+# blocks (npm, swagger, ofc) on every iteration, not just the empty one.
+setup_work_tree () {
+    local work="$1"
+    mkdir -p \
+        "$work/web/log" \
+        "$work/git/demo_farm_openemr/pieces" \
+        "$work/capsules" \
+        "$work/tmp"
+    touch "$work/git/demo_farm_openemr/openemr-alpine.conf"
+
+    # demosGo iterates over ("empty" "a" "b" ... "i"); "empty" maps to
+    # $WEB/openemr while letters map to $WEB/$letter/openemr. Seed both.
+    local sub
+    for sub in "" a b c d e f g h i; do
+        local oe
+        if [[ -z "$sub" ]]; then
+            oe="$work/web/openemr"
+        else
+            oe="$work/web/$sub/openemr"
+        fi
+        mkdir -p \
+            "$oe/sites/default/documents" \
+            "$oe/contrib/util/installScripts" \
+            "$oe/swagger" \
+            "$oe/library/openflashchart/php-ofc-library" \
+            "$oe/ccdaservice" \
+            "$oe/interface/modules/zend_modules/config"
+
+        # Marker files (gated `[ -f ... ]` checks in demo_build.sh).
+        touch \
+            "$oe/sites/default/sqlconf.php" \
+            "$oe/package.json" \
+            "$oe/ccdaservice/package.json" \
+            "$oe/contrib/util/installScripts/InstallerAuto.php" \
+            "$oe/swagger/openemr-api.yaml" \
+            "$oe/library/openflashchart/php-ofc-library/ofc_upload_image.php" \
+            "$oe/sql_upgrade.php"
+
+        # version.php content matters: collect_var pulls $v_major out of it
+        # and the script branches on $v_major >= 6 (utf8mb4 collation block).
+        # Default to a modern major so the branch is exercised. Per-fixture
+        # extra/web/<sub>/openemr/version.php may override.
+        printf '<?php\n$v_major = "7";\n' > "$oe/version.php"
+    done
+}
+
+# Normalize the captured action log: replace the throwaway $WORK path
+# with the literal token <WORK> so goldens are portable across runs.
+normalize_action_log () {
+    local work="$1"
+    local action_log="$2"
+    # Escape regex metachars in $work before sed (path is /tmp/something).
+    local work_esc
+    work_esc="$(printf '%s' "$work" | sed 's|[\\/.[^$*]|\\&|g')"
+    sed -i "s|${work_esc}|<WORK>|g" "$action_log"
+}
+
+run_one_fixture () {
+    local fixture_dir="$1"
+    local name
+    name="$(basename "$fixture_dir")"
+
+    local inputs="$fixture_dir/inputs.env"
+    local ip_map="$fixture_dir/ip_map_branch.txt"
+    local extra_dir="$fixture_dir/extra"
+    local expected="$fixture_dir/expected/action-log.txt"
+
+    if [[ ! -f "$inputs" ]]; then
+        echo "  FAIL: missing $inputs"
+        return 1
+    fi
+    if [[ ! -f "$ip_map" ]]; then
+        echo "  FAIL: missing $ip_map"
+        return 1
+    fi
+
+    local work
+    work="$(mktemp -d)"
+    WORK_DIRS+=("$work")
+
+    setup_work_tree "$work"
+    cp "$ip_map" "$work/git/demo_farm_openemr/ip_map_branch.txt"
+    if [[ -d "$extra_dir" ]]; then
+        # `cp -a extra/. $work/` overlays the fixture's extras on top of
+        # the kitchen-sink tree (per-scenario marker contents).
+        cp -a "$extra_dir/." "$work/"
+    fi
+
+    local action_log="$work/action.log"
+
+    # Source the fixture's env. Defaults applied for keys it doesn't set.
+    DOCKERDEMO=""
+    DOCKERMYSQLHOST="mysql"
+    DOCKERNUMBERDEMOS=""
+    PHP_VERSION_ABBR="85"
+    EXTRA_ARGS=""
+    # shellcheck disable=SC1090
+    source "$inputs"
+
+    if [[ -z "$DOCKERDEMO" ]]; then
+        echo "  FAIL: inputs.env must set DOCKERDEMO"
+        return 1
+    fi
+
+    # Run the script. Pipe stdout/stderr to /dev/null -- only the action
+    # log matters here; the script's verbose status output would drown
+    # the test summary otherwise.
+    set +e
+    DOCKERDEMO="$DOCKERDEMO" \
+    DOCKERMYSQLHOST="$DOCKERMYSQLHOST" \
+    DOCKERNUMBERDEMOS="$DOCKERNUMBERDEMOS" \
+    PHP_VERSION_ABBR="$PHP_VERSION_ABBR" \
+    WEB="$work/web" \
+    webUser="root" \
+    GITMAIN="$work/git" \
+    GITDEMOFARM="$work/git/demo_farm_openemr" \
+    CAPSULES="$work/capsules" \
+    OPENEMRTMPDIR="$work/tmp" \
+    ACTION_LOG="$action_log" \
+        bash "$DEMO_BUILD" --dry-run $EXTRA_ARGS >"$work/script.stdout" 2>"$work/script.stderr"
+    local exit_code=$?
+    set -e
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo "  FAIL: demo_build.sh --dry-run exited $exit_code"
+        echo "  stdout (tail):"
+        tail -n 20 "$work/script.stdout" | sed 's/^/    | /'
+        echo "  stderr (tail):"
+        tail -n 20 "$work/script.stderr" | sed 's/^/    | /'
+        return 1
+    fi
+
+    normalize_action_log "$work" "$action_log"
+
+    if [[ "$UPDATE_GOLDENS" = "1" ]]; then
+        mkdir -p "$(dirname "$expected")"
+        cp "$action_log" "$expected"
+        echo "  UPDATED: $expected"
+        return 0
+    fi
+
+    if [[ ! -f "$expected" ]]; then
+        echo "  FAIL: missing golden $expected"
+        echo "  hint: run with UPDATE_GOLDENS=1 to seed it"
+        return 1
+    fi
+
+    if ! diff -u "$expected" "$action_log" > "$work/diff.out" 2>&1; then
+        echo "  FAIL: action log differs from golden"
+        sed 's/^/    | /' "$work/diff.out"
+        return 1
+    fi
+
+    echo "  PASS"
+    return 0
+}
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+if [[ ! -d "$FIXTURES_DIR" ]] || [[ -z "$(find "$FIXTURES_DIR" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]]; then
+    echo "No fixtures found under $FIXTURES_DIR" >&2
+    exit 2
+fi
+
+for fixture_dir in "$FIXTURES_DIR"/*/; do
+    name="$(basename "$fixture_dir")"
+    echo "=== fixture: $name ==="
+    if run_one_fixture "$fixture_dir"; then
+        PASS=$((PASS+1))
+    else
+        FAIL=$((FAIL+1))
+        FAILED_NAMES+=("$name")
+    fi
+done
+
+echo
+echo "=========================="
+echo "fixtures passed: $PASS"
+echo "fixtures failed: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "failed:"
+    for n in "${FAILED_NAMES[@]}"; do echo "  - $n"; done
+    exit 1
+fi
+exit 0

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -206,7 +206,11 @@ run_one_fixture () {
             echo "  FAIL: expected non-zero exit (fail marker present) but got 0"
             return 1
         fi
-        if ! cat "$work/script.stdout" "$work/script.stderr" | grep -qF "$expected_msg"; then
+        # grep the files directly rather than `cat … | grep -qF`: under
+        # `set -o pipefail` (enabled at the top of this script), grep
+        # closing stdin early on a match makes cat exit with SIGPIPE,
+        # which would turn a passing case into a false failure.
+        if ! grep -qF -- "$expected_msg" "$work/script.stdout" "$work/script.stderr"; then
             echo "  FAIL: expected error substring '$expected_msg' not found in output"
             echo "  stdout (tail):"
             tail -n 20 "$work/script.stdout" | sed 's/^/    | /'
@@ -220,6 +224,19 @@ run_one_fixture () {
 
     if [[ $exit_code -ne 0 ]]; then
         echo "  FAIL: demo_build.sh --dry-run exited $exit_code"
+        echo "  stdout (tail):"
+        tail -n 20 "$work/script.stdout" | sed 's/^/    | /'
+        echo "  stderr (tail):"
+        tail -n 20 "$work/script.stderr" | sed 's/^/    | /'
+        return 1
+    fi
+
+    # Defensive: if a regression makes demo_build.sh exit 0 without
+    # producing an action log, fail this fixture cleanly rather than
+    # letting `sed -i` on a missing file trip `set -e` and abort the
+    # whole harness mid-run.
+    if [[ ! -f "$action_log" ]]; then
+        echo "  FAIL: missing action log $action_log (script exited 0 but produced no log)"
         echo "  stdout (tail):"
         tail -n 20 "$work/script.stdout" | sed 's/^/    | /'
         echo "  stderr (tail):"

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -24,11 +24,20 @@
 #                                     extra/capsules/<name>.tgz
 #   expected/action-log.txt      -- the golden, with $WORK paths replaced
 #                                   by the literal token <WORK>.
+#                                   OR
+#   expected/fail.txt             -- substring expected in stderr/stdout
+#                                   when the script is supposed to abort
+#                                   (e.g., the useCapsuleFile guard). The
+#                                   harness asserts exit != 0 AND the
+#                                   substring is present; action-log.txt
+#                                   is not required for fail-expected
+#                                   fixtures.
 #
 # To regenerate a fixture's golden after intentional changes to
 # demo_build.sh, run:
 #   UPDATE_GOLDENS=1 ./tools/build-tests/test.sh
-# and review the diff before committing.
+# and review the diff before committing. (UPDATE_GOLDENS is a no-op for
+# fail-expected fixtures -- fail.txt is hand-authored.)
 
 set -euo pipefail
 
@@ -130,6 +139,7 @@ run_one_fixture () {
     local ip_map="$fixture_dir/ip_map_branch.txt"
     local extra_dir="$fixture_dir/extra"
     local expected="$fixture_dir/expected/action-log.txt"
+    local fail_marker="$fixture_dir/expected/fail.txt"
 
     if [[ ! -f "$inputs" ]]; then
         echo "  FAIL: missing $inputs"
@@ -186,6 +196,27 @@ run_one_fixture () {
         bash "$DEMO_BUILD" --dry-run $EXTRA_ARGS >"$work/script.stdout" 2>"$work/script.stderr"
     local exit_code=$?
     set -e
+
+    if [[ -f "$fail_marker" ]]; then
+        # Fail-expected fixture: assert exit != 0 AND substring present in
+        # combined stderr/stdout. Skips action-log diffing entirely.
+        local expected_msg
+        expected_msg="$(cat "$fail_marker")"
+        if [[ $exit_code -eq 0 ]]; then
+            echo "  FAIL: expected non-zero exit (fail marker present) but got 0"
+            return 1
+        fi
+        if ! cat "$work/script.stdout" "$work/script.stderr" | grep -qF "$expected_msg"; then
+            echo "  FAIL: expected error substring '$expected_msg' not found in output"
+            echo "  stdout (tail):"
+            tail -n 20 "$work/script.stdout" | sed 's/^/    | /'
+            echo "  stderr (tail):"
+            tail -n 20 "$work/script.stderr" | sed 's/^/    | /'
+            return 1
+        fi
+        echo "  PASS (expected fail: '$expected_msg', exit=$exit_code)"
+        return 0
+    fi
 
     if [[ $exit_code -ne 0 ]]; then
         echo "  FAIL: demo_build.sh --dry-run exited $exit_code"


### PR DESCRIPTION
## Summary

Phase 1 of #146 — per-PR regression coverage for `demo_build.sh`.

`demo_build.sh --dry-run` skips side-effecting commands (composer, npm, mariadb, apk, git clone, curl, httpd, postfix, stunnel, system-path writes) but emits a structured `ACTION:` log line for each one through three new helpers: `run_action` (argv), `run_action_sh` (pipes/redirects), `run_action_capture` (with stub value for `$(curl …)` style capture). Pure parsing/branching code still runs, so the action log captures *what the script intended to do*.

`tools/build-tests/test.sh` runs each fixture's `ip_map_branch.txt` through `demo_build.sh --dry-run`, normalizes the captured action log (replaces the throwaway work-dir path with the literal token `<WORK>`), and diffs against the golden in `expected/action-log.txt`. Mirrors the `tools/auto-derive/fixtures-and-tests/` pattern that #135 introduced.

Credential redaction in the emitter covers `-p<pass>` (mariadb root flag), `rootpass=<pass>` (InstallerAuto arg), `Authorization: token <key>` (composer github API probe), and `--auth github-oauth.github.com <key>` (composer config). Dry-run stubs don't get touched (`<DRY_RUN_GITHUB_KEY>` becomes `\<…\>` after `%q`, which dodges the `[A-Za-z0-9_]+` body match); Phase 2 live runs would otherwise leak the real token to `ACTION_LOG`.

## Scenarios

**Seven fixtures**, picked from real production rows where possible to exercise the actual branching surface of the script:

| Scenario | Row(s) | Coverage |
| --- | --- | --- |
| `branch-pinned-master` | `two` | master clone, udt=1 (dev translations), ppapi=1 (portal/API globals), random theme (ThemeTwo) |
| `tag-pinned-with-data` | `five` | v8_0_0_3 tag clone, demo data SQL, demoDataUpgrade (sed transforms + ALTER TABLE/DATABASE on `$v_major≥6`), random theme (ThemeOne) |
| `release-packageserve` | `six` | v7_0_4 tag, `sp=1` → exercises the entire ~80-line packageServe block (a second composer/npm/phing pass + tar/zip/md5sum packaging) |
| `up-for-grabs-fork` | `four_a` | non-canonical fork URL (juggernautsei/openemr.git) + non-canonical branch + demo data |
| `light-reset` | `two_a` + positional arg | `lightReset=true` path, single-subdemo, skips post-loop block |
| `multi-demo` | `seven`/`seven_a`/`seven_b` | `DOCKERNUMBERDEMOS=3` loop iteration |
| `capsule-path-traversal` | synthetic `malcap` | **fail-expected** — synthetic row with `capsule="../etc"` exercises the case statement guard PR #145 added (`'' | */* | . | ..)`). Pins the rejection so a future regression that drops the guard fails CI. Uses the `expected/fail.txt` substring + non-zero exit pattern mirrored from the auto-derive harness. |

## CI

`.github/workflows/build-tests.yml` runs the suite on every PR touching `demo_build.sh`, `tools/build-tests/**`, or the workflow itself. Wall time: seconds.

Two `.shellcheckrc` entries added (`SC3043` `local`, `SC3050` `printf %q`) — same rationale as the five existing SC3xxx disables: the script carries a stale `#!/bin/sh` shebang while using bash features throughout, and the new helpers extend that gap by two more bashisms. Consistent with the ratchet's existing posture.

## What's NOT in this PR

- **Live end-to-end execution.** That's Phase 2 (PR #148, stacked on this one) — actually runs `demo_build.sh` against a real mariadb + openemr flex container in CI matrix-parallel, and asserts the resulting container survives a healthcheck plus its action log matches a per-fixture golden.

## Test plan

- [x] `./tools/build-tests/test.sh` — all 7 PASS locally
- [x] Mutation test: deliberately stripped the capsule path-traversal guard → only that fixture FAILed (negative test of the new fail-expected harness path)
- [x] `shellcheck demo_build.sh tools/build-tests/test.sh` — clean
- [x] `bash -n demo_build.sh` — clean
- [x] Production-call surface unchanged: with no `--dry-run` and no `ACTION_LOG` env var, helpers append to `/dev/null` and exec the wrapped command — behavior is byte-identical to pre-PR for the docker entrypoint callers
- [x] CI: all checks green (ShellCheck, build-tests dry-run, Derive ip_map test, CodeRabbit)

Refs: #146 (issue), #135 (fixture pattern this mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
