### PR TITLE
feat(build-tests): Phase 2 — live end-to-end integration tests (#146)

### DIFF
--- a/.github/workflows/build-tests-live.yml
+++ b/.github/workflows/build-tests-live.yml
@@ -11,14 +11,16 @@ name: build-tests (live integration)
 # another. Scenario list MUST stay in sync with tools/build-tests/
 # integration/run-all.sh (the local-execution wrapper).
 #
-# Trigger:
-#   - pull_request: ON during Phase 2 PR development (visible feedback
-#     on every push). This will be dropped before merge -- per-PR is too
-#     slow for the value once we have nightly coverage.
-#   - workflow_dispatch: manual reruns (kept post-merge).
-#   - schedule: TODO -- add `cron: '0 8 * * *'` (daily 08:00 UTC, 1h
-#     after the auto-derive reconcile job) before merging this PR, in
-#     the same commit that drops `pull_request`.
+# Trigger (three paths, complementary):
+#   - pull_request: per-push feedback on PRs that touch the live-test
+#     surface. Made feasible by the matrix below -- slowest cell is
+#     ~10 min, so it's tractable as blocking CI for a low-volume repo.
+#   - schedule: 08:00 UTC daily, 1h after the auto-derive reconcile
+#     job. Catches the class of regression no PR could -- upstream
+#     image bumps (Alpine, mariadb 10.6 → 10.7, openemr/flex) that
+#     break demo_build.sh's assumptions without anyone editing it.
+#   - workflow_dispatch: manual reruns (debug a flaky scheduled run
+#     without waiting for tomorrow's tick).
 
 on:
   pull_request:
@@ -26,6 +28,9 @@ on:
       - demo_build.sh
       - tools/build-tests/**
       - .github/workflows/build-tests-live.yml
+  schedule:
+    # Daily 08:00 UTC, 1h after the derive-ip-map reconcile job (07:00).
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-tests-live.yml
+++ b/.github/workflows/build-tests-live.yml
@@ -5,10 +5,11 @@ name: build-tests (live integration)
 # state (schemas + globals table) and diffs the captured action log
 # against a per-scenario golden.
 #
-# Slow (~20-45 min). Three scenarios: branch-pinned-master,
-# tag-pinned-with-data, release-packageserve. Chosen to exercise
-# distinct expensive code paths (master clone, tag clone + demoData +
-# utf8mb4 ALTERs, packageServe tar/zip flow).
+# Matrix-parallel: one job per scenario on its own ubuntu-24.04 runner.
+# Wall time = slowest scenario (~8-10 min) instead of sum (~25 min); each
+# scenario gets a fresh VM so leftover state from one can never affect
+# another. Scenario list MUST stay in sync with tools/build-tests/
+# integration/run-all.sh (the local-execution wrapper).
 #
 # Trigger:
 #   - pull_request: ON during Phase 2 PR development (visible feedback
@@ -33,28 +34,44 @@ concurrency:
 
 jobs:
   live:
+    name: live (${{ matrix.scenario }})
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 60
+    # Per-cell ceiling: 20 min covers composer + npm + webpack + InstallerAuto
+    # with plenty of slack for slow CI runners. Sequential default was 60
+    # for all three.
+    timeout-minutes: 20
+    strategy:
+      # Don't cancel sibling cells on a single failure -- we want to see
+      # all results when debugging (otherwise rerunning just the failed
+      # cell still leaves the question "would the others have passed?").
+      fail-fast: false
+      matrix:
+        # MUST stay in sync with tools/build-tests/integration/run-all.sh.
+        # The 4 omitted Phase 1 fixtures (light-reset, multi-demo,
+        # capsule-path-traversal, up-for-grabs-fork) stay dry-run-only --
+        # see run-all.sh for the cost/signal rationale.
+        scenario:
+          - branch-pinned-master
+          - tag-pinned-with-data
+          - release-packageserve
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - name: Pre-pull openemr flex images
-        # All three scenarios currently target flex-3.22 tags (php-8.2
-        # for two, php-8.4 for five/six). Pull serially so docker layer
-        # dedup works; saves wall time vs the runner first hitting these
-        # mid-scenario.
+      - name: Pre-pull base images
+        # All three current scenarios target the same flex tag. If a
+        # fixture overrides INTEGRATION_IMAGE, the runner will pull
+        # that on-demand at first `docker run` inside run-scenario.sh.
         run: |
           set -euo pipefail
           docker pull mariadb:10.6
           docker pull openemr/openemr:flex-3.22-php-8.2
-          docker pull openemr/openemr:flex-3.22-php-8.4
 
-      - name: Run Phase 2 integration suite
+      - name: Run scenario ${{ matrix.scenario }} (live)
         # On failure, run-scenario.sh prints the openemr container logs
         # + the demo_build.sh setup-log tail to stderr; both surface in
         # the workflow log. No need for separate artifact upload at this
@@ -62,4 +79,4 @@ jobs:
         # so reviewers can see it without running CI.
         run: |
           set -euo pipefail
-          ./tools/build-tests/integration/run-all.sh
+          ./tools/build-tests/integration/run-scenario.sh ${{ matrix.scenario }}

--- a/.github/workflows/build-tests-live.yml
+++ b/.github/workflows/build-tests-live.yml
@@ -1,0 +1,65 @@
+name: build-tests (live integration)
+
+# Phase 2 of issue #146: actually runs demo_build.sh end-to-end against
+# a real mariadb + openemr flex container, then checks the resulting
+# state (schemas + globals table) and diffs the captured action log
+# against a per-scenario golden.
+#
+# Slow (~20-45 min). Three scenarios: branch-pinned-master,
+# tag-pinned-with-data, release-packageserve. Chosen to exercise
+# distinct expensive code paths (master clone, tag clone + demoData +
+# utf8mb4 ALTERs, packageServe tar/zip flow).
+#
+# Trigger:
+#   - pull_request: ON during Phase 2 PR development (visible feedback
+#     on every push). This will be dropped before merge -- per-PR is too
+#     slow for the value once we have nightly coverage.
+#   - workflow_dispatch: manual reruns (kept post-merge).
+#   - schedule: TODO -- add `cron: '0 8 * * *'` (daily 08:00 UTC, 1h
+#     after the auto-derive reconcile job) before merging this PR, in
+#     the same commit that drops `pull_request`.
+
+on:
+  pull_request:
+    paths:
+      - demo_build.sh
+      - tools/build-tests/**
+      - .github/workflows/build-tests-live.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  live:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Pre-pull openemr flex images
+        # All three scenarios currently target flex-3.22 tags (php-8.2
+        # for two, php-8.4 for five/six). Pull serially so docker layer
+        # dedup works; saves wall time vs the runner first hitting these
+        # mid-scenario.
+        run: |
+          set -euo pipefail
+          docker pull mariadb:10.6
+          docker pull openemr/openemr:flex-3.22-php-8.2
+          docker pull openemr/openemr:flex-3.22-php-8.4
+
+      - name: Run Phase 2 integration suite
+        # On failure, run-scenario.sh prints the openemr container logs
+        # + the demo_build.sh setup-log tail to stderr; both surface in
+        # the workflow log. No need for separate artifact upload at this
+        # stage -- the action log is also seeded as a golden in the repo,
+        # so reviewers can see it without running CI.
+        run: |
+          set -euo pipefail
+          ./tools/build-tests/integration/run-all.sh

--- a/tools/build-tests/fixtures/branch-pinned-master/expected/live-action-log.txt
+++ b/tools/build-tests/fixtures/branch-pinned-master/expected/live-action-log.txt
@@ -1,0 +1,37 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = /var/www/localhost/htdocs/log/logPhp.txt' > /etc/php82/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch master --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "/var/www/localhost/htdocs/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git /home/openemr/git/openemr/* /var/www/localhost/htdocs/openemr/
+ACTION: rm -fr /home/openemr/git/openemr
+ACTION: chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/documents
+ACTION: chmod a+w /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\  https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm run build &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' </var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php >/var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "apache" -c "php -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php development_translations=yes rootpass=<REDACTED> server=<MARIADB_HOST> loginhost=% login=two pass=two dbname=two" >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: rm -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e UPDATE\ two.globals\ SET\ gl_value=\'https://two.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e UPDATE\ two.globals\ SET\ gl_value=\'<LIVE_RANDOM_THEME>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e $'\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE two.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE two.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: mkdir /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: postfix start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: cp /home/openemr/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/release-packageserve/expected/live-action-log.txt
+++ b/tools/build-tests/fixtures/release-packageserve/expected/live-action-log.txt
@@ -1,0 +1,59 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = /var/www/localhost/htdocs/log/logPhp.txt' > /etc/php82/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch v7_0_4 --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "/var/www/localhost/htdocs/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git /home/openemr/git/openemr/* /var/www/localhost/htdocs/openemr/
+ACTION: chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/documents
+ACTION: chmod a+w /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\  https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm run build &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' </var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php >/var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "apache" -c "php -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=<MARIADB_HOST> loginhost=% login=six pass=six dbname=six" >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: rm -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e UPDATE\ six.globals\ SET\ gl_value=\'https://six.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e $'\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE six.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE six.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: mkdir /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION_SH: rsync --recursive --exclude .git /home/openemr/git/openemr/* /tmp/openemr-tmp/openemr/
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\  https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm run build &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: rm -fr "/tmp/openemr-tmp/openemr/node_modules" &>> "/var/www/localhost/htdocs/log/logSetup.txt"
+ACTION_SH: composer dump-autoload -o &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: chmod a+w /tmp/openemr-tmp/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w /tmp/openemr-tmp/openemr/sites/default/documents
+ACTION: chmod a+w /tmp/openemr-tmp/openemr/interface/modules/zend_modules/config/application.config.php
+ACTION: rm -f /var/www/localhost/htdocs/files/openemr-cvs.tar.gz
+ACTION: tar -czf /var/www/localhost/htdocs/files/openemr-cvs.tar.gz openemr
+ACTION_SH: md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt
+ACTION: rm -f /var/www/localhost/htdocs/files/openemr-cvs.zip
+ACTION: zip -rq /var/www/localhost/htdocs/files/openemr-cvs.zip openemr
+ACTION_SH: md5sum openemr-cvs.zip > openemr-windows-md5.txt
+ACTION_SH: date > date-cvs.txt
+ACTION: rm -fr /tmp/openemr-tmp
+ACTION: rm -fr /home/openemr/git/openemr
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: postfix start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: cp /home/openemr/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/fixtures/tag-pinned-with-data/expected/live-action-log.txt
+++ b/tools/build-tests/fixtures/tag-pinned-with-data/expected/live-action-log.txt
@@ -1,0 +1,46 @@
+ACTION: apk add --no-cache postfix stunnel
+ACTION_SH: echo 'error_log = /var/www/localhost/htdocs/log/logPhp.txt' > /etc/php82/conf.d/99-demo-farm-error-log.ini
+ACTION: git clone --branch v8_0_0_3 --depth 1 https://github.com/openemr/openemr.git
+ACTION_SH: rm -fr "/var/www/localhost/htdocs/openemr"/*
+ACTION_SH: rsync --recursive --exclude .git /home/openemr/git/openemr/* /var/www/localhost/htdocs/openemr/
+ACTION: rm -fr /home/openemr/git/openemr
+ACTION: chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/documents
+ACTION: chmod a+w /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
+ACTION_CAPTURE: cat /home/openemr/github-key
+ACTION_CAPTURE: curl -H Authorization:\ token\  https://api.github.com/rate_limit
+ACTION_SH: composer install --no-dev &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm run build &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: npm install --unsafe-perm &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global require phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing vendor-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: /root/.composer/vendor/bin/phing assets-clean &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer global remove phing/phing &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: composer dump-autoload -o &>> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: sed -e 's@^exit;@ @' </var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php >/var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: su -p -s /bin/sh "apache" -c "php -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php rootpass=<REDACTED> server=<MARIADB_HOST> loginhost=% login=five pass=five dbname=five" >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: rm -f /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAutoTemp.php
+ACTION_SH: mariadb-dump --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> --add-drop-table --no-data five | grep ^DROP | awk ' BEGIN { print "SET FOREIGN_KEY_CHECKS=0;" } { print $0 } END { print "SET FOREIGN_KEY_CHECKS=1;" } ' | mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> five
+ACTION_SH: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> five < "/home/openemr/git/demo_farm_openemr/pieces/demo_5_0_0_5.sql"
+ACTION_SH: sed -e "s@!empty(\$_POST\['form_submit'\])@true@" </var/www/localhost/htdocs/openemr/sql_upgrade.php >/var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '5.0.0';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+ACTION_SH: sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+ACTION_SH: su -p -s /bin/sh "apache" -c "php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php" >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+ACTION_SH: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | egrep '^ALTER' | mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED>
+ACTION_SH: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"five"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | egrep '^ALTER' | mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED>
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e UPDATE\ five.globals\ SET\ gl_value=\'https://demo.openemr.io\'\ WHERE\ gl_name=\'site_addr_oath\'
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e UPDATE\ five.globals\ SET\ gl_value=\'<LIVE_RANDOM_THEME>\'\ WHERE\ gl_name=\'css_header\'
+ACTION: mariadb --skip-ssl -h <MARIADB_HOST> -u root -p<REDACTED> -e $'\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'portal_onsite_two_enable\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_fhir_api\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_portal_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'oauth_password_grant\';\n    UPDATE five.globals SET gl_value=\'1\' WHERE gl_name=\'rest_system_scopes_api\';\n    UPDATE five.globals SET gl_value=\'3\' WHERE gl_name=\'ccda_alt_service_enable\';\n  '
+ACTION: chmod 644 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
+ACTION: mkdir /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: chmod -R a+w /var/www/localhost/htdocs/openemr/sites/default/procedure_results
+ACTION: sed -i s@/apis/default/@/openemr/apis/default/@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/authorize@/openemr/oauth2/default/authorize@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION: sed -i s@/oauth2/default/token@/openemr/oauth2/default/token@ /var/www/localhost/htdocs/openemr/swagger/openemr-api.yaml
+ACTION_SH: stunnel /etc/stunnel/stunnel.conf >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION_SH: postfix start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: cp /home/openemr/git/demo_farm_openemr/openemr-alpine.conf /etc/apache2/conf.d/openemr.conf
+ACTION_SH: httpd -k start >> /var/www/localhost/htdocs/log/logSetup.txt
+ACTION: tail -F -n0 /etc/hosts

--- a/tools/build-tests/integration/run-all.sh
+++ b/tools/build-tests/integration/run-all.sh
@@ -19,6 +19,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUNNER="$SCRIPT_DIR/run-scenario.sh"
 
+# MUST stay in sync with the matrix in
+# .github/workflows/build-tests-live.yml. CI parallelizes these via the
+# matrix; this script runs them sequentially for local use.
 LIVE_SCENARIOS=(
     branch-pinned-master
     tag-pinned-with-data

--- a/tools/build-tests/integration/run-all.sh
+++ b/tools/build-tests/integration/run-all.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# run-all.sh -- run the Phase 2 integration suite (3 representative
+# scenarios that exercise distinct, expensive live behavior).
+#
+# The 4 remaining Phase 1 fixtures stay dry-run-only:
+#   light-reset, multi-demo: cost vs signal is wrong (3x composer/npm
+#       for the loop test; lightReset just gates the post-loop block).
+#   capsule-path-traversal: fail-expected, no live behavior.
+#   up-for-grabs-fork: depends on a third-party fork's branch state
+#       (flaky-by-design; not our regression to catch).
+#
+# Per-scenario timeouts are inherited from run-scenario.sh (default
+# 900s = 15 min). On a CI runner without composer/npm caches the
+# total wall time is ~30-45 min; with caches ~15-20 min.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUNNER="$SCRIPT_DIR/run-scenario.sh"
+
+LIVE_SCENARIOS=(
+    branch-pinned-master
+    tag-pinned-with-data
+    release-packageserve
+)
+
+PASS=0
+FAIL=0
+FAILED_NAMES=()
+
+for sc in "${LIVE_SCENARIOS[@]}"; do
+    echo
+    echo "############################################################"
+    echo "# Phase 2 scenario: $sc"
+    echo "############################################################"
+    if "$RUNNER" "$sc"; then
+        PASS=$((PASS+1))
+    else
+        FAIL=$((FAIL+1))
+        FAILED_NAMES+=("$sc")
+    fi
+done
+
+echo
+echo "=========================="
+echo "Phase 2 integration summary"
+echo "  passed: $PASS"
+echo "  failed: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+    echo "failed scenarios:"
+    for n in "${FAILED_NAMES[@]}"; do
+        echo "  - $n"
+    done
+    exit 1
+fi
+exit 0

--- a/tools/build-tests/integration/run-scenario.sh
+++ b/tools/build-tests/integration/run-scenario.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+#
+# run-scenario.sh -- run ONE Phase 2 integration test scenario end-to-end.
+#
+# Stands up mariadb + the openemr/openemr:flex base image, runs
+# demo_build.sh against the fixture's ip_map_branch.txt, and asserts:
+#   1. demo_build.sh reaches the "Demo install script is complete" marker
+#      (i.e., walked the full code path including composer/npm install,
+#      mariadb populate, apache start) within the timeout.
+#   2. The fixture's database(s) exist in mariadb with the expected
+#      OpenEMR tables populated (sanity check on the install + demo data).
+#   3. The action log was written and contains the expected sequence of
+#      sentinel ACTION lines (a per-fixture live-mode golden under
+#      tools/build-tests/fixtures/<scenario>/expected/live-action-log.txt).
+#
+# Designed to run from the repo root inside CI or on a host with docker.
+# Cleans up its containers + network on EXIT (success or failure) and
+# leaves no orphaned state behind.
+#
+# Usage:
+#   run-scenario.sh <scenario-name> [--image <flex-tag>] [--timeout <sec>]
+#
+# Env vars:
+#   UPDATE_GOLDENS=1   Overwrite expected/live-action-log.txt with the
+#                      captured (normalized) live log. Review the diff
+#                      before committing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FIXTURES_DIR="$REPO_ROOT/tools/build-tests/fixtures"
+DEMO_BUILD="$REPO_ROOT/demo_build.sh"
+
+SCENARIO=""
+# Default to the production flex image tag used by the `two` cluster
+# (Alpine 3.22 / PHP 8.2). Per-fixture inputs.env may override via
+# INTEGRATION_IMAGE.
+IMAGE="openemr/openemr:flex-3.22-php-8.2"
+TIMEOUT_SECONDS=900   # 15 min ceiling for composer + npm + mariadb populate
+UPDATE_GOLDENS="${UPDATE_GOLDENS:-0}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image)   IMAGE="$2"; shift 2 ;;
+        --timeout) TIMEOUT_SECONDS="$2"; shift 2 ;;
+        --*)       echo "Unknown flag: $1" >&2; exit 2 ;;
+        *)
+            if [[ -z "$SCENARIO" ]]; then
+                SCENARIO="$1"
+                shift
+            else
+                echo "Unexpected positional arg: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$SCENARIO" ]]; then
+    echo "Usage: $0 <scenario-name> [--image <tag>] [--timeout <sec>]" >&2
+    exit 2
+fi
+
+FIXTURE_DIR="$FIXTURES_DIR/$SCENARIO"
+if [[ ! -d "$FIXTURE_DIR" ]]; then
+    echo "Fixture not found: $FIXTURE_DIR" >&2
+    exit 2
+fi
+
+# Unique resource names per invocation. PID + random keep concurrent runs
+# from colliding on the docker network/container names.
+SUFFIX="$$-$RANDOM"
+NETWORK="bt-net-$SUFFIX"
+MARIADB="bt-mariadb-$SUFFIX"
+OPENEMR="bt-openemr-$SUFFIX"
+WORK="$(mktemp -d -t bt-run-XXXXXX)"
+
+cleanup () {
+    set +e
+    docker stop "$OPENEMR"  >/dev/null 2>&1
+    docker rm   "$OPENEMR"  >/dev/null 2>&1
+    docker stop "$MARIADB"  >/dev/null 2>&1
+    docker rm   "$MARIADB"  >/dev/null 2>&1
+    docker network rm "$NETWORK" >/dev/null 2>&1
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# Normalize the live action log so per-run-varying values are replaced
+# with stable placeholders. Two sources of variance:
+#   1. $MARIADB container name = "bt-mariadb-$PID-$RANDOM", embedded in
+#      `mariadb -h <host>` arg by demo_build.sh via $DOCKERMYSQLHOST.
+#   2. RANDOM_THEME picks a CSS file at random from one of the
+#      getRandomThemeOne/Two arrays (style_<name>.css).
+# Phase 1's `_emit_action_log` helper already redacts `-p<pass>` and
+# `rootpass=<pass>`, so $mrp doesn't need handling here.
+normalize_live_log () {
+    local raw="$1"
+    local out="$2"
+    sed -E \
+        -e "s/${MARIADB}/<MARIADB_HOST>/g" \
+        -e 's/style_[a-z_]+\.css/<LIVE_RANDOM_THEME>/g' \
+        "$raw" > "$out"
+}
+
+echo "=== Phase 2 integration: scenario=$SCENARIO image=$IMAGE ==="
+echo "    work dir: $WORK"
+
+# Source fixture inputs. Required: DOCKERDEMO. Optional: DOCKERNUMBERDEMOS,
+# EXTRA_ARGS, INTEGRATION_IMAGE (per-fixture image override).
+DOCKERDEMO=""
+DOCKERNUMBERDEMOS=""
+PHP_VERSION_ABBR=""
+EXTRA_ARGS=""
+INTEGRATION_IMAGE=""
+# shellcheck disable=SC1091
+source "$FIXTURE_DIR/inputs.env"
+
+if [[ -z "$DOCKERDEMO" ]]; then
+    echo "FAIL: $FIXTURE_DIR/inputs.env must set DOCKERDEMO" >&2
+    exit 1
+fi
+if [[ -n "$INTEGRATION_IMAGE" ]]; then
+    IMAGE="$INTEGRATION_IMAGE"
+fi
+
+# Skip fail-expected fixtures: they're a Phase 1 concern (assert script
+# rejects bad input before any side effect) and have no live behavior to
+# integration-test.
+if [[ -f "$FIXTURE_DIR/expected/fail.txt" ]]; then
+    echo "    skip: fail-expected fixture (Phase 1 covers; nothing to live-test)"
+    exit 0
+fi
+
+# Build a fixture-specific GITDEMOFARM tree the openemr container will
+# bind-mount read-only at /home/openemr/git/demo_farm_openemr. Production
+# clones the whole demo_farm_openemr repo into the container; we mount
+# the local checkout instead so we test the local demo_build.sh + the
+# fixture's ip_map_branch.txt (not master's).
+FAKE_GITDEMOFARM="$WORK/git/demo_farm_openemr"
+mkdir -p "$FAKE_GITDEMOFARM/pieces"
+cp "$FIXTURE_DIR/ip_map_branch.txt" "$FAKE_GITDEMOFARM/"
+cp "$DEMO_BUILD"                    "$FAKE_GITDEMOFARM/demo_build.sh"
+cp "$REPO_ROOT/openemr-alpine.conf" "$FAKE_GITDEMOFARM/"
+cp "$REPO_ROOT/set_pass.php"        "$FAKE_GITDEMOFARM/"
+if [[ -d "$FIXTURE_DIR/extra/git/demo_farm_openemr/pieces" ]]; then
+    cp -a "$FIXTURE_DIR/extra/git/demo_farm_openemr/pieces/." "$FAKE_GITDEMOFARM/pieces/"
+fi
+
+# Overlay the real demo data SQL files from $REPO_ROOT/pieces/ on top.
+# Phase 1 dry-run fixtures carry empty marker files for the SQL (the
+# mariadb load is wrapped + skipped, so only the `[ -f ... ]` gate
+# matters). For Phase 2 live execution the actual file content is
+# needed -- without it the mariadb-dump|DROP|mariadb-load cycle wipes
+# the OpenEMR schema installed by InstallerAuto and replaces it with
+# nothing, leaving an empty database.
+if [[ -d "$REPO_ROOT/pieces" ]]; then
+    cp -a "$REPO_ROOT/pieces/." "$FAKE_GITDEMOFARM/pieces/"
+fi
+
+echo "--- start mariadb ---"
+docker network create "$NETWORK" >/dev/null
+docker run --detach --name "$MARIADB" \
+    --network "$NETWORK" \
+    --env "MYSQL_ROOT_PASSWORD=hey" \
+    --ulimit nofile=65536:65536 \
+    mariadb:10.6 \
+    --max-connections=450 \
+    --character-set-server=utf8mb4 \
+    >/dev/null
+
+# Wait for mariadb to accept connections. Tight inner sleep, generous
+# outer bound -- cold start is usually 5-10 sec, slow CI runners up to 30.
+mariadb_ready=0
+for _ in $(seq 1 60); do
+    if docker exec "$MARIADB" mariadb -uroot -phey -e "SELECT 1" >/dev/null 2>&1; then
+        mariadb_ready=1
+        break
+    fi
+    sleep 1
+done
+if [[ $mariadb_ready -ne 1 ]]; then
+    echo "FAIL: mariadb never came up; container logs:" >&2
+    docker logs "$MARIADB" 2>&1 | tail -50 >&2
+    exit 1
+fi
+
+echo "--- start openemr container + run demo_build.sh ---"
+# Run detached so we can poll the marker. The script's tail -F at the
+# end keeps the container alive forever in production; we stop the
+# container ourselves once the completion marker fires.
+docker run --detach --name "$OPENEMR" \
+    --network "$NETWORK" \
+    --env "DOCKERDEMO=$DOCKERDEMO" \
+    --env "DOCKERMYSQLHOST=$MARIADB" \
+    --env "DOCKERNUMBERDEMOS=${DOCKERNUMBERDEMOS:-1}" \
+    --env "OPENEMR_DOCKER_ENV_TAG=demo-farm" \
+    --env "THROTTLE_DOWN_WAIT_MILLISECONDS=700" \
+    --env "THROTTLE_DOWN_DIE_MILLISECONDS=10000" \
+    --env "ACTION_LOG=/var/log/action-log.txt" \
+    -v "$FAKE_GITDEMOFARM:/home/openemr/git/demo_farm_openemr:ro" \
+    "$IMAGE" \
+    bash -c "bash /home/openemr/git/demo_farm_openemr/demo_build.sh ${EXTRA_ARGS}" \
+    >/dev/null
+
+# Poll the script's own log for the completion marker. demo_build.sh
+# writes "Demo install script is complete" to $LOG (= $WEB/log/logSetup.txt
+# = /var/www/localhost/htdocs/log/logSetup.txt) AFTER the loop and the
+# apache start, just before the hold-open tail -F.
+echo "--- wait for completion marker (timeout: ${TIMEOUT_SECONDS}s) ---"
+SETUP_LOG="/var/www/localhost/htdocs/log/logSetup.txt"
+completed=0
+deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+while [[ $(date +%s) -lt $deadline ]]; do
+    if docker exec "$OPENEMR" grep -q "Demo install script is complete" "$SETUP_LOG" 2>/dev/null; then
+        completed=1
+        break
+    fi
+    # If the container died before the marker, no point polling further.
+    if ! docker inspect -f '{{.State.Running}}' "$OPENEMR" 2>/dev/null | grep -q true; then
+        echo "FAIL: openemr container exited before completion marker" >&2
+        echo "  container logs (last 80):" >&2
+        docker logs "$OPENEMR" 2>&1 | tail -80 | sed 's/^/    | /' >&2
+        echo "  setup log (last 80):" >&2
+        docker exec "$OPENEMR" tail -n 80 "$SETUP_LOG" 2>/dev/null | sed 's/^/    | /' >&2 || true
+        exit 1
+    fi
+    sleep 5
+done
+
+if [[ $completed -ne 1 ]]; then
+    echo "FAIL: completion marker not seen within ${TIMEOUT_SECONDS}s" >&2
+    echo "  setup log (last 80):" >&2
+    docker exec "$OPENEMR" tail -n 80 "$SETUP_LOG" 2>/dev/null | sed 's/^/    | /' >&2 || true
+    exit 1
+fi
+
+echo "    ok: completion marker seen"
+
+echo "--- mariadb state check ---"
+# Assert the fixture's primary database exists. For multi-demo we also
+# check the subdemo schemas. demo_build.sh creates one schema per loop
+# iteration named $DOCKERDEMO (or ${DOCKERDEMOORIGINAL}_${demo} for subs).
+expected_dbs=("$DOCKERDEMO")
+if [[ "${DOCKERNUMBERDEMOS}" =~ ^[2-9]$|^10$ ]]; then
+    for sub in a b c d e f g h i; do
+        # demosGo for DOCKERNUMBERDEMOS=N covers ("empty" "a"..letter[N-2])
+        # — quick heuristic: include subs up to N-1.
+        idx=$(printf '%s' "abcdefghi" | head -c $((DOCKERNUMBERDEMOS - 1)) | tr -d '\n')
+        if [[ "$idx" == *"$sub"* ]]; then
+            expected_dbs+=("${DOCKERDEMO}_${sub}")
+        fi
+    done
+fi
+db_list="$(docker exec "$MARIADB" mariadb -uroot -phey -B -N -e 'SHOW DATABASES')"
+for db in "${expected_dbs[@]}"; do
+    if ! grep -qFx "$db" <<<"$db_list"; then
+        echo "FAIL: expected database '$db' not found in mariadb" >&2
+        echo "  databases present:" >&2
+        echo "$db_list" | sed 's/^/    | /' >&2
+        exit 1
+    fi
+    # Sanity check: OpenEMR's install always creates the `globals` table.
+    if ! docker exec "$MARIADB" mariadb -uroot -phey -B -N -e "USE \`$db\`; SHOW TABLES LIKE 'globals';" 2>/dev/null | grep -qx globals; then
+        echo "FAIL: database '$db' has no 'globals' table -- install likely failed" >&2
+        echo "  setup log (last 80):" >&2
+        docker exec "$OPENEMR" tail -n 80 "$SETUP_LOG" 2>/dev/null | sed 's/^/    | /' >&2 || true
+        exit 1
+    fi
+done
+echo "    ok: ${#expected_dbs[@]} database(s) present with globals table"
+
+echo "--- capture + normalize live action log ---"
+docker cp "$OPENEMR:/var/log/action-log.txt" "$WORK/live-action-log.raw.txt"
+normalize_live_log "$WORK/live-action-log.raw.txt" "$WORK/live-action-log.txt"
+
+echo "--- diff vs golden ---"
+expected="$FIXTURE_DIR/expected/live-action-log.txt"
+if [[ "$UPDATE_GOLDENS" = "1" ]]; then
+    mkdir -p "$(dirname "$expected")"
+    cp "$WORK/live-action-log.txt" "$expected"
+    echo "    UPDATED: $expected"
+    exit 0
+fi
+if [[ ! -f "$expected" ]]; then
+    echo "FAIL: missing golden $expected" >&2
+    echo "  hint: run with UPDATE_GOLDENS=1 to seed it" >&2
+    exit 1
+fi
+if ! diff -u "$expected" "$WORK/live-action-log.txt" >"$WORK/diff.out" 2>&1; then
+    echo "FAIL: live action log differs from golden" >&2
+    sed 's/^/    | /' "$WORK/diff.out" >&2
+    exit 1
+fi
+echo "    ok: live action log matches golden"
+
+echo "=== PASS: $SCENARIO ==="

--- a/tools/build-tests/integration/run-scenario.sh
+++ b/tools/build-tests/integration/run-scenario.sh
@@ -37,12 +37,13 @@ SCENARIO=""
 # (Alpine 3.22 / PHP 8.2). Per-fixture inputs.env may override via
 # INTEGRATION_IMAGE.
 IMAGE="openemr/openemr:flex-3.22-php-8.2"
+IMAGE_FROM_CLI=0  # set when --image is passed; takes precedence over inputs.env
 TIMEOUT_SECONDS=900   # 15 min ceiling for composer + npm + mariadb populate
 UPDATE_GOLDENS="${UPDATE_GOLDENS:-0}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --image)   IMAGE="$2"; shift 2 ;;
+        --image)   IMAGE="$2"; IMAGE_FROM_CLI=1; shift 2 ;;
         --timeout) TIMEOUT_SECONDS="$2"; shift 2 ;;
         --*)       echo "Unknown flag: $1" >&2; exit 2 ;;
         *)
@@ -121,7 +122,10 @@ if [[ -z "$DOCKERDEMO" ]]; then
     echo "FAIL: $FIXTURE_DIR/inputs.env must set DOCKERDEMO" >&2
     exit 1
 fi
-if [[ -n "$INTEGRATION_IMAGE" ]]; then
+if [[ -n "$INTEGRATION_IMAGE" && "$IMAGE_FROM_CLI" -eq 0 ]]; then
+    # Fixture override only applies when --image wasn't explicitly passed;
+    # CLI wins so callers can A/B-test against a different image without
+    # editing the fixture.
     IMAGE="$INTEGRATION_IMAGE"
 fi
 

--- a/tools/build-tests/integration/run-scenario.sh
+++ b/tools/build-tests/integration/run-scenario.sh
@@ -110,9 +110,16 @@ echo "    work dir: $WORK"
 
 # Source fixture inputs. Required: DOCKERDEMO. Optional: DOCKERNUMBERDEMOS,
 # EXTRA_ARGS, INTEGRATION_IMAGE (per-fixture image override).
+#
+# PHP_VERSION_ABBR is intentionally NOT consumed here: the flex base
+# image bakes it in (e.g., "82" for flex-3.22-php-8.2), and we never
+# override it via --env on the container. The fixture inputs.env still
+# carries the var because Phase 1 dry-run runs outside any flex image
+# and needs the value for the script's `echo … > /etc/php${ABBR}/...`
+# path. Sourcing-and-not-using here would imply a contract Phase 2
+# doesn't actually have.
 DOCKERDEMO=""
 DOCKERNUMBERDEMOS=""
-PHP_VERSION_ABBR=""
 EXTRA_ARGS=""
 INTEGRATION_IMAGE=""
 # shellcheck disable=SC1091


### PR DESCRIPTION
## Summary

Phase 2 of #146 — live end-to-end integration tests for `demo_build.sh`.

Builds on #147 (Phase 1's dry-run suite, merged as 91477d1). The diff here is rebased onto master and shows only the Phase 2 changes.

`tools/build-tests/integration/run-scenario.sh` stands up `mariadb:10.6` + an `openemr/openemr:flex-3.22-php-8.2` container on an isolated docker network, runs `demo_build.sh` for real (composer install, npm install, webpack themes build, OpenEMR install, mariadb populate, apache start), then asserts:

1. The script reaches its "Demo install script is complete" marker within a 20-min timeout (i.e., walked the full happy path including the slow phases that dry-run skips).
2. Every expected database exists in mariadb and has a `globals` table (sanity check that `InstallerAuto.php` actually ran).
3. The captured action log matches a per-fixture `expected/live-action-log.txt` golden (after normalizing the per-run-varying mariadb container hostname and the randomly-picked theme value).

Same fixtures Phase 1 uses; no fixture duplication. Container + network are cleaned up on EXIT (success or failure).

## Scenarios run live

Three of Phase 1's seven, picked to exercise distinct expensive behavior:

| Fixture | What this catches in live mode that dry-run can't |
| --- | --- |
| `branch-pinned-master` | master clone + real composer dep resolution + webpack themes build + ppapi globals UPDATE + dev-translations install path |
| `tag-pinned-with-data` | tag clone + demo data SQL load + demoDataUpgrade (sed transforms + ALTER TABLE/DATABASE on `$v_major≥6`) |
| `release-packageserve` | the entire packageServe block — a second composer/npm/phing pass in a staging dir + tar/zip/md5sum packaging output |

The 4 remaining stay dry-run-only — `light-reset`/`multi-demo` are too expensive per signal added (lightReset just gates the post-loop block; multi-demo costs 3× composer for what action-log diff already proves); `capsule-path-traversal` exits before any side effect; `up-for-grabs-fork` depends on a community fork's branch state (flaky-by-design).

## CI: matrix-parallel + scheduled

`.github/workflows/build-tests-live.yml` runs each scenario on its own `ubuntu-24.04` runner via `strategy.matrix`. Wall time = slowest cell (~10 min) instead of sum (~25 min sequential). `fail-fast: false` so a single cell failing doesn't cancel its siblings — debugging needs to see all three results.

**Actual matrix timings observed on this PR:**

| Cell | Wall time |
| --- | --- |
| `live (branch-pinned-master)` | 3m30s |
| `live (tag-pinned-with-data)` | 8m21s |
| `live (release-packageserve)` | 9m53s |
| **Workflow wall time** | **9m53s** (vs **24m43s** sequential — ~60% reduction) |

**Three triggers**, complementary:
- **`pull_request`** — per-push feedback on PRs that touch `demo_build.sh` / `tools/build-tests/**`. Made viable by the matrix cutting wall time to ~10 min.
- **`schedule: '0 8 * * *'`** — daily 08:00 UTC, 1h after the auto-derive reconcile. Catches the class no PR triggers: upstream image bumps (Alpine, mariadb 10.6 → 10.7, openemr/flex) that break `demo_build.sh` assumptions without anyone editing it.
- **`workflow_dispatch`** — manual reruns for debugging a flaky scheduled run.

## What this PR deliberately does NOT do

- **Direct diff against Phase 1 dry-run goldens.** Each fixture gets its own `expected/live-action-log.txt` instead. A direct diff would need Phase 1 goldens redesigned with abstract path tokens (`<OPENEMR>` instead of `<WORK>/web/openemr`) — non-trivial scope creep. The two-golden split lets human reviewers diff both files manually if they want the "dry-run vs live drift" signal. (Real example surfaced during smoke testing: dry-run logs `rm -f ofc_upload_image.php` because the fixture pre-creates the marker file; live doesn't, because upstream openemr already removed that file. Both behaviors are correct — the script handles both presence and absence — but the goldens differ on that line.)
- **Composer/npm caching.** First iteration accepts cold runs. `actions/cache` for `~/.composer/cache` + `~/.npm` is a small follow-up that would bring per-cell time down further.
- **Artifact upload on failure.** `run-scenario.sh` already prints container logs + setup-log tail on every failure path; visible in the workflow log.
- **GitHub auth for composer.** No `github-key` is mounted in CI, so the script's `cat /home/openemr/github-key` fails (silently, no `set -e`), the rate-limit curl returns 60-remaining from an unauthenticated call, and the script takes the "not using composer github api token" branch. Works for one nightly run; risk if rate-limited.

## Rabbit-flagged items addressed mid-review

- `1a21699` — `--image` CLI flag now takes precedence over fixture's `INTEGRATION_IMAGE` (lets callers A/B-test a scenario against a different image without editing the fixture).
- `625cda9` — drop dead `PHP_VERSION_ABBR` sourcing in `run-scenario.sh` (the flex image provides its own; runner-side source was a contract this script doesn't actually have).
- `fa9e75b` — matrix conversion (this).
- `9de9553` — schedule trigger added; pre-merge `pull_request`-drop TODO retired.

## Test plan

- [x] `./tools/build-tests/integration/run-scenario.sh branch-pinned-master` — local smoke (PASS)
- [x] `./tools/build-tests/integration/run-all.sh` locally — all 3 scenarios (PASS)
- [x] CI matrix on this PR — all 3 cells green at 9m53s slowest
- [x] Manual review of each live golden (`expected/live-action-log.txt`) — production paths, normalized hostnames + theme + redacted secrets, expected branching covered
- [x] CodeRabbit: review completed (2 actionable rounds addressed; remaining nitpicks documented in comment thread with rationale)

Refs: #146 (issue), #147 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
