### PR TITLE
ci(shellcheck): drop 9 disables (shebang flip + trivial-category fixes)

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -13,34 +13,10 @@
 
 external-sources=true
 
-# Pre-existing style/info notices. ShellCheck's `severity=warning` rc directive
-# is ignored when invoked with `--format=checkstyle` (the workflow's mode),
-# so we silence these by code instead of by severity.
-disable=SC1001  # `\=` is a regular `=` (1)
-disable=SC2001  # use bash substitution instead of sed (2)
-disable=SC2005  # useless echo (1)
-disable=SC2006  # use `$(...)` instead of backticks (88)
-disable=SC2016  # expressions don't expand in single quotes (5)
-disable=SC2086  # double quote to prevent globbing/word splitting (1255) -- bulk of repo noise
-disable=SC2129  # consider `{ cmd1; cmd2; } > file` (2)
-disable=SC2196  # `egrep` is non-standard (2)
-
-# Pre-existing POSIX-sh warnings, all emitted from demo_build.sh which carries
-# a stale `#!/bin/sh` shebang but uses bash features (arrays, `[[`, `==`)
-# throughout. The right fix is to switch the shebang to bash; until then,
-# ShellCheck flags every bashism as undefined-in-POSIX. (77 violations)
-disable=SC3014  # `==` in place of `=`
-disable=SC3028  # `RANDOM` undefined
-disable=SC3030  # arrays undefined
-disable=SC3037  # `echo` flags undefined
-disable=SC3043  # `local` undefined -- used by the build-tests helpers added in #146
-disable=SC3050  # `printf %q` undefined -- used by the build-tests action-log emitter (#146)
-disable=SC3054  # array references undefined
-
 # Pre-existing bash warnings deferred to follow-up cleanup PRs.
 disable=SC1090  # can't follow non-constant source (9 violations)
+disable=SC2006  # use `$(...)` instead of backticks (88 violations)
 disable=SC2034  # appears unused (7 violations)
-disable=SC2046  # quote to prevent word splitting (1 violation)
-disable=SC2048  # use `"${array[@]}"` with quotes (1 violation)
+disable=SC2086  # double quote to prevent globbing/word splitting (1255) -- bulk of repo noise
 disable=SC2155  # declare and assign separately (4 violations) -- masks return values
 disable=SC2164  # `cd ... || exit` (25 violations)

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (C) 2014 Brady Miller <brady@sparmy.com>
 #
 #This program is free software; you can redistribute it and/or modify
@@ -202,7 +202,7 @@ getRandomThemeTwo () {
 #function to collect variables from config files
 # 1st param is variable name, 2nd param is filename
 collect_var () {
-   echo `grep -i "^[[:space:]]*$1[[:space:]=]" $2 | cut -d \= -f 2 | cut -d \; -f 1 | sed "s/[ 	'\"]//gi"`
+   grep -i "^[[:space:]]*$1[[:space:]=]" "$2" | cut -d = -f 2 | cut -d ';' -f 1 | sed "s/[ 	'\"]//gi"
 }
 
 # (lightReset / lightResetDemo are now set by the unified arg parser at the
@@ -311,7 +311,7 @@ fi
 
 DOCKERDEMOORIGINAL=$DOCKERDEMO
 
-for demo in ${demosGo[*]}
+for demo in "${demosGo[@]}"
 do
 
  if [ "$demo" == "empty" ]; then

--- a/tools/auto-derive/derive.sh
+++ b/tools/auto-derive/derive.sh
@@ -1327,6 +1327,7 @@ render_demolib() {
                 fi
                 if [[ "$line" =~ ^[[:space:]]+case[[:space:]]+\"\$1\" ]]; then
                     # emit new case body
+                    # shellcheck disable=SC2016  # literal $1 emitted into generated bash
                     printf '    case "$1" in\n'
                     local cluster
                     for cluster in "${all_bases[@]}"; do

--- a/tools/auto-derive/fixtures-and-tests/test.sh
+++ b/tools/auto-derive/fixtures-and-tests/test.sh
@@ -66,6 +66,7 @@ for fixture_dir in "$FIXTURES_DIR"/*/; do
             PASS=$((PASS+1))
         else
             echo "  FAIL: expected failure with substring '$expected_msg'; got exit=$exit_code, output:"
+            # shellcheck disable=SC2001  # consistent sed idiom across this file's failure paths
             echo "$output" | sed 's/^/    | /'
             FAIL=$((FAIL+1))
             FAILED_NAMES+=("$name")
@@ -76,6 +77,7 @@ for fixture_dir in "$FIXTURES_DIR"/*/; do
 
     if [[ $exit_code -ne 0 ]]; then
         echo "  FAIL: derive.sh exited $exit_code"
+        # shellcheck disable=SC2001  # consistent sed idiom across this file's failure paths
         echo "$output" | sed 's/^/    | /'
         FAIL=$((FAIL+1))
         FAILED_NAMES+=("$name")

--- a/tools/build-tests/integration/run-scenario.sh
+++ b/tools/build-tests/integration/run-scenario.sh
@@ -269,6 +269,7 @@ for db in "${expected_dbs[@]}"; do
     if ! grep -qFx "$db" <<<"$db_list"; then
         echo "FAIL: expected database '$db' not found in mariadb" >&2
         echo "  databases present:" >&2
+        # shellcheck disable=SC2001  # consistent sed idiom across this file's failure paths
         echo "$db_list" | sed 's/^/    | /' >&2
         exit 1
     fi

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -117,6 +117,7 @@ setup_work_tree () {
         # and the script branches on $v_major >= 6 (utf8mb4 collation block).
         # Default to a modern major so the branch is exercised. Per-fixture
         # extra/web/<sub>/openemr/version.php may override.
+        # shellcheck disable=SC2016  # literal $v_major in output is intentional
         printf '<?php\n$v_major = "7";\n' > "$oe/version.php"
     done
 }


### PR DESCRIPTION
## Summary

PR A of the ShellCheck ratchet cleanup. Drops **9 disables** from `.shellcheckrc` in a single targeted PR.

The build-tests suites from #147 (dry-run, 7 fixtures) and #148 (live, 3 matrix cells) are the regression net that makes this safe to do as one PR rather than the cautious per-category splits the ratchet was originally established for.

## What changed

| Disable | Violations cleaned | How |
| --- | --- | --- |
| `SC3014` `==` | all | shebang flip on `demo_build.sh` |
| `SC3028` `RANDOM` | all | shebang flip |
| `SC3030` arrays | all | shebang flip |
| `SC3037` `echo -n` | all | shebang flip |
| `SC3043` `local` | all | shebang flip (was added by #147) |
| `SC3050` `printf %q` | all | shebang flip (was added by #147) |
| `SC3054` array refs | all | shebang flip |
| `SC1001` `\=` | 1 (`demo_build.sh:205`) | removed meaningless backslash |
| `SC2046` unquoted `$()` | 1 (`demo_build.sh:205`) | refactored `collect_var` to drop redundant `echo` wrapper |
| `SC2005` useless `echo $()` | 1 (`demo_build.sh:205`) | same refactor |
| `SC2048` `${arr[*]}` | 1 (`demo_build.sh:314`) | `${demosGo[*]}` → `"${demosGo[@]}"` |
| `SC2016` literal `$` in single-quoted printf | 2 (test.sh:120, derive.sh:1330) | inline disable — `$` is intentional in printf output |
| `SC2001` `echo "$var" \| sed 's/^/.../'` | 3 (across 2 files) | inline disable per site — 14 other unflagged `sed 's/^/...'` sites in same files use file/cmd-output shape; rewriting only the 3 flagged ones would split the codebase between two idioms |

## Verification

- `shellcheck --check-sourced --external-sources` on every `*.sh` / `*.source` in the repo (excluding fixtures) — clean.
- `./tools/build-tests/test.sh` — 7/7 PASS.
- `./tools/auto-derive/fixtures-and-tests/test.sh` — 8/8 PASS.

## What's left after this PR

`.shellcheckrc` will still carry 6 disables, all queued for follow-up PRs per the analysis on the original #146 thread:

- `SC2164` `cd … || exit` (25 sites) — **PR B**, real safety value (silent `cd` failures leave the script running in the wrong directory).
- `SC2086` unquoted `$VAR` (1255 sites) — **PR C**, the bulk; needs per-site eyeballs because some uses intentionally rely on word splitting.
- `SC2006` backticks → `$(…)` (88 sites), `SC2155` masked exit status (4 sites), `SC2034` unused (7 sites), `SC1090` non-constant `source` (9 sites) — fold into PR C since you're touching every line anyway.

## Risk

The two demo_build.sh refactors (`collect_var` rewrite + `${demosGo[@]}` quoting change) are the only behavioral changes; both verified by the dry-run suite's 7 fixtures all passing. The shebang flip is a no-op since production already invokes via `bash -c demo_build.sh`. Everything else is shellcheck-rc-only or inline annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up shell script warnings and standardized shell-check annotations across build and test tooling.
  * Improved script robustness by switching one build script to Bash and handling array values more safely.
  * Kept generated output and verification scripts aligned with shell-check expectations, with no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->