### PR TITLE
ci(shellcheck): drop SC2164 disable + guard all 25 cd sites

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -19,4 +19,3 @@ disable=SC2006  # use `$(...)` instead of backticks (88 violations)
 disable=SC2034  # appears unused (7 violations)
 disable=SC2086  # double quote to prevent globbing/word splitting (1255) -- bulk of repo noise
 disable=SC2155  # declare and assign separately (4 violations) -- masks return values
-disable=SC2164  # `cd ... || exit` (25 violations)

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -484,7 +484,7 @@ IPADDRESS=$DOCKERDEMO
   echo "Downloading the OpenEMR git repository"
   echo "Downloading the OpenEMR git repository" >> $LOG
   mkdir -p $GITMAIN
-  cd $GITMAIN
+  cd $GITMAIN || exit 1
   # `--branch <ref>` accepts both branch names and tag names; combined with
   # `--depth 1` this gives a shallow clone of the exact ref.
   run_action git clone --branch "$GITBRANCH" --depth 1 "$OPENEMRREPO"
@@ -520,7 +520,7 @@ IPADDRESS=$DOCKERDEMO
 
  #Build openemr package
  if [ ! -d $OPENEMR/vendor ]; then
-  cd $OPENEMR
+  cd $OPENEMR || exit 1
 
   # install php dependencies. In dry-run we stub a fake key and a rate-limit
   # of 0 so the "Not using composer github api token" branch is exercised
@@ -549,9 +549,9 @@ IPADDRESS=$DOCKERDEMO
 
   if [ -f $OPENEMR/ccdaservice/package.json ]; then
    # install ccdaservice dependencies (need unsafe-perm to run as root)
-   cd $OPENEMR/ccdaservice
+   cd $OPENEMR/ccdaservice || exit 1
    run_action_sh "npm install --unsafe-perm &>> $LOG"
-   cd $OPENEMR
+   cd $OPENEMR || exit 1
   fi
 
   # clean up
@@ -781,7 +781,7 @@ IPADDRESS=$DOCKERDEMO
   run_action_sh "rsync --recursive --exclude .git $GIT/* $TMPDIR/openemr/"
   #Build openemr package
   if [ ! -d $TMPDIR/openemr/vendor ]; then
-   cd $TMPDIR/openemr
+   cd $TMPDIR/openemr || exit 1
 
    # install php dependencies (see twin block above for the dry-run stub rationale)
    GITHUB_KEY_COMPOSER=$(run_action_capture --stub '<DRY_RUN_GITHUB_KEY>' cat /home/openemr/github-key)
@@ -831,17 +831,17 @@ IPADDRESS=$DOCKERDEMO
   mkdir $FILESSERVEDIR
 
   # Save the tar.gz cvs package
-  cd $TMPDIR
+  cd $TMPDIR || exit 1
   run_action rm -f $FILESSERVEDIR/openemr-cvs.tar.gz
   run_action tar -czf $FILESSERVEDIR/openemr-cvs.tar.gz openemr
-  cd $FILESSERVEDIR
+  cd $FILESSERVEDIR || exit 1
   run_action_sh "md5sum openemr-cvs.tar.gz > openemr-linux-md5.txt"
 
   # Save the .zip cvs package
-  cd $TMPDIR
+  cd $TMPDIR || exit 1
   run_action rm -f $FILESSERVEDIR/openemr-cvs.zip
   run_action zip -rq $FILESSERVEDIR/openemr-cvs.zip openemr
-  cd $FILESSERVEDIR
+  cd $FILESSERVEDIR || exit 1
   run_action_sh "md5sum openemr-cvs.zip > openemr-windows-md5.txt"
 
   # Create the time stamp

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -296,9 +296,9 @@ snapshotDemo() {
         mysqldump --ignore-table=${1}_${2}.onsite_activity_view --hex-blob -u root -p${3} -h ${MYSQLIP} ${1}_${2} > "${tmpPath}/backup.sql"
         docker cp "${1}-openemr:/var/www/localhost/htdocs/${2}/openemr/sites" "${tmpPath}"
     fi
-    cd "${tmp}"
+    cd "${tmp}" || return 1
     tar -czf "${snapshotName}.tgz" "${snapshotName}"
     mv "${snapshotName}.tgz" "${capsules}/"
     rm -fr "${tmpPath}"
-    cd ~
+    cd ~ || return 1
 }

--- a/docker/scripts/refreshWebsite.sh
+++ b/docker/scripts/refreshWebsite.sh
@@ -11,10 +11,10 @@
 #
 
 # update demo_farm_openemr repo which contains the website
-cd ~/demo_farm_openemr
+cd ~/demo_farm_openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # copy over website
 cp -r ~/demo_farm_openemr/docker/html/* ~/html/

--- a/docker/scripts/restartFarm.sh
+++ b/docker/scripts/restartFarm.sh
@@ -17,23 +17,23 @@ docker pull openemr/openemr:flex-3.22-php-8.4
 docker pull openemr/openemr:flex-3.22-php-8.2
 
 # update demo_farm_openemr repo
-cd ~/demo_farm_openemr
+cd ~/demo_farm_openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # update translations_development_openemr repo and place in html dir
-cd ~/translations_development_openemr
+cd ~/translations_development_openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/translations/
 
 # update optional wkhtmltopdf-openemr
-cd ~/wkhtmltopdf-openemr
+cd ~/wkhtmltopdf-openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # rebuild simple website and copy translations to website
 cp -r ~/demo_farm_openemr/docker/html/* ~/html/

--- a/docker/scripts/restartFarm.sh
+++ b/docker/scripts/restartFarm.sh
@@ -30,10 +30,16 @@ cd ~/ || exit 1
 cp ~/translations_development_openemr/languageTranslations_utf8.sql ~/html/translations/
 
 # update optional wkhtmltopdf-openemr
-cd ~/wkhtmltopdf-openemr || exit 1
-git fetch origin
-git pull origin master
-cd ~/ || exit 1
+# Comment marks this repo as optional. Pre-cd-guard code tolerated a
+# missing directory because the unguarded `cd` silently failed; preserve
+# that "skip if absent" semantic explicitly now that cd is hard-exit on
+# failure.
+if [ -d ~/wkhtmltopdf-openemr ]; then
+  cd ~/wkhtmltopdf-openemr || exit 1
+  git fetch origin
+  git pull origin master
+  cd ~/ || exit 1
+fi
 
 # rebuild simple website and copy translations to website
 cp -r ~/demo_farm_openemr/docker/html/* ~/html/

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -66,10 +66,16 @@ git pull origin master
 cd ~/ || exit 1
 
 # update optional wkhtmltopdf-openemr
-cd ~/wkhtmltopdf-openemr || exit 1
-git fetch origin
-git pull origin master
-cd ~/ || exit 1
+# Comment + the install-instructions header above mark this repo as
+# optional. Pre-cd-guard code tolerated a missing directory because the
+# unguarded `cd` silently failed; preserve that "skip if absent"
+# semantic explicitly now that cd is hard-exit on failure.
+if [ -d ~/wkhtmltopdf-openemr ]; then
+  cd ~/wkhtmltopdf-openemr || exit 1
+  git fetch origin
+  git pull origin master
+  cd ~/ || exit 1
+fi
 
 # rebuild simple website and copy translations to website
 cp -r ~/demo_farm_openemr/docker/html/* ~/html/

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -54,22 +54,22 @@ docker pull openemr/openemr:flex-3.22-php-8.2
 docker network create mynet
 
 # update demo_farm_openemr repo
-cd ~/demo_farm_openemr
+cd ~/demo_farm_openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # update translations_development_openemr repo and place in html dir
-cd ~/translations_development_openemr
+cd ~/translations_development_openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # update optional wkhtmltopdf-openemr
-cd ~/wkhtmltopdf-openemr
+cd ~/wkhtmltopdf-openemr || exit 1
 git fetch origin
 git pull origin master
-cd ~/
+cd ~/ || exit 1
 
 # rebuild simple website and copy translations to website
 cp -r ~/demo_farm_openemr/docker/html/* ~/html/


### PR DESCRIPTION
## Summary

PR B of the ShellCheck ratchet cleanup. Drops **`SC2164`** from `.shellcheckrc` after guarding all 25 `cd` sites in the repo.

The bug class: `cd $X` without `|| exit` (or `|| return` in a function) silently fails and leaves the script running in the wrong directory. Any subsequent `rm -fr`, `git pull`, `tar -czf` then operates somewhere it shouldn't. Same class of footgun as the SC2115 unguarded-`rm` cases #145 cleaned up, but harder to spot because the wrong directory is *downstream* of the failure rather than at the call site.

## Sites guarded

| File | Sites | Guard |
| --- | --- | --- |
| `demo_build.sh` | 9 | `|| exit 1` (top-level cd inside the demosGo loop) |
| `docker/scripts/startFarm.sh` | 6 | `|| exit 1` (repo-update pattern: `cd ~/<repo>; git pull; cd ~/`) |
| `docker/scripts/restartFarm.sh` | 6 | `|| exit 1` (same pattern) |
| `docker/scripts/refreshWebsite.sh` | 2 | `|| exit 1` (same pattern) |
| `docker/scripts/demoLibrary.source` | 2 | `|| return 1` (inside `snapshotDemo()` function, bubble failure to caller) |
| **Total** | **25** | |

## Verification

- `shellcheck --check-sourced --external-sources` on every `*.sh` / `*.source` (excluding fixtures) — clean.
- `./tools/build-tests/test.sh` — 7/7 PASS.
- `./tools/auto-derive/fixtures-and-tests/test.sh` — 8/8 PASS.

The dry-run suite is the load-bearing safety net here: the cd guards run *before* every wrapped command in `demo_build.sh`, so a regression that introduced a silently-failing cd would now exit loudly during the test rather than running the test with broken state.

## State of `.shellcheckrc` after this PR

5 disables remaining (was 15 before the cleanup series began with #147):

- `SC2086` (1255 sites) — **PR C**, the big one. Per-site eyeball audit because some uses intentionally rely on word splitting.
- `SC2006` (88 backticks → `$()`), `SC2155` (4 masked exit statuses), `SC2034` (7 apparently unused), `SC1090` (9 non-constant `source`) — fold into PR C since the SC2086 audit touches every line anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across demo, build, snapshot packaging, website refresh, and farm restart/start workflows by failing fast when directory changes fail.
  * Added guarded directory navigation around git updates and packaging steps to prevent commands from running in the wrong location.
  * Tightened shell linting configuration by removing an outdated rule suppression while keeping all other settings unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->