### PR TITLE
ci(shellcheck): drop SC1090 + SC2034 (source directives + dead-code prune)

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -14,8 +14,6 @@
 external-sources=true
 
 # Pre-existing bash warnings deferred to follow-up cleanup PRs.
-disable=SC1090  # can't follow non-constant source (9 violations)
 disable=SC2006  # use `$(...)` instead of backticks (88 violations)
-disable=SC2034  # appears unused (7 violations)
 disable=SC2086  # double quote to prevent globbing/word splitting (1255) -- bulk of repo noise
 disable=SC2155  # declare and assign separately (4 violations) -- masks return values

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -238,6 +238,16 @@ GITDEMOFARM="${GITDEMOFARM:-$GITMAIN/demo_farm_openemr}"
 GITDEMOFARMMAP_SRC=$GITDEMOFARM/ip_map_branch.txt
 GITDEMOFARMMAP=$(mktemp)
 grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"
+# PASSWORDRESETSCRIPT, FINALWEB (assigned per-iteration below), passResetAuto
+# (derived from $passReset / column 16 below), and the commented-out invocation
+# near the end of the demosGo loop body are kept together as the entry points
+# for the automated password-reset daemon. The feature is currently disabled
+# pending the bug tracked at openemr/openemr#5991 (see commits 4e3a2ba +
+# a393d37, Dec 2022). The pass_reset column is still populated in
+# ip_map_branch.txt for production rows on the assumption that re-enabling is
+# a one-line uncomment, not a rewrite.
+# shellcheck disable=SC2034  # consumed by the commented-out re-enable site; openemr/openemr#5991
+PASSWORDRESETSCRIPT=$GITDEMOFARM/set_pass.php
 OPENEMRAPACHECONF=$GITDEMOFARM/openemr-alpine.conf
 # OPENEMRTMPDIR (vs TMPDIR(1), used implicitly by mktemp et al.) overrides
 # the staging directory for the openemr CVS package built in the packageServe
@@ -316,10 +326,14 @@ do
   OPENEMR=$WEB/openemr
   FILESSERVEDIR=$WEB/files
   DOCKERDEMO=$DOCKERDEMOORIGINAL
+  # shellcheck disable=SC2034  # consumed by the commented-out password-reset block at end of loop; openemr/openemr#5991
+  FINALWEB=$WEB
  else
   DOCKERDEMO=${DOCKERDEMOORIGINAL}_${demo}
   OPENEMR=${WEB}/${demo}/openemr
   FILESSERVEDIR=$WEB/${demo}/files
+  # shellcheck disable=SC2034  # consumed by the commented-out password-reset block at end of loop; openemr/openemr#5991
+  FINALWEB=$WEB/${demo}
  fi
 
  # Collect ip address or docker demo number
@@ -452,6 +466,15 @@ IPADDRESS=$DOCKERDEMO
   randomTheme=false;
  else
   randomTheme=true;
+ fi
+ # set if doing password reset
+ # (if 1, then will reset just admin, if 2, then will reset all the official demo users)
+ if [ "$passReset" == "0" ]; then
+  # shellcheck disable=SC2034  # consumed by the commented-out password-reset block at end of loop; openemr/openemr#5991
+  passResetAuto=false;
+ else
+  # shellcheck disable=SC2034  # consumed by the commented-out password-reset block at end of loop; openemr/openemr#5991
+  passResetAuto=true;
  fi
  # set if using a capsule
  if [ "$useCapsule" == "0" ]; then
@@ -843,6 +866,16 @@ IPADDRESS=$DOCKERDEMO
   echo "Done creating OpenEMR Development packages" >> $LOG
  fi
 
+ # Automated password-reset daemon: temporarily disabled per
+ # openemr/openemr#5991 (see commits 4e3a2ba + a393d37, Dec 2022).
+ # When the upstream bug is fixed, uncomment the `if/nohup/fi` lines
+ # below to re-enable; the variables PASSWORDRESETSCRIPT, FINALWEB,
+ # passResetAuto, and the column-16 $passReset value are all kept in
+ # place expressly so re-enabling is a 3-line uncomment, not a rewrite.
+ #if $passResetAuto; then
+  # run the auto reset password script every 5 minutes
+  #nohup php -f ${PASSWORDRESETSCRIPT} ${FINALWEB} 300 ${passReset} >/dev/null 2>&1 &
+ #fi
 done
 
 # Start Postfix for restarts, uses stunnel to communicate to aws ses email server.

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -238,9 +238,7 @@ GITDEMOFARM="${GITDEMOFARM:-$GITMAIN/demo_farm_openemr}"
 GITDEMOFARMMAP_SRC=$GITDEMOFARM/ip_map_branch.txt
 GITDEMOFARMMAP=$(mktemp)
 grep -v '^#' "$GITDEMOFARMMAP_SRC" > "$GITDEMOFARMMAP"
-PASSWORDRESETSCRIPT=$GITDEMOFARM/set_pass.php
 OPENEMRAPACHECONF=$GITDEMOFARM/openemr-alpine.conf
-GITTRANS=$GITMAIN/translations_development_openemr
 # OPENEMRTMPDIR (vs TMPDIR(1), used implicitly by mktemp et al.) overrides
 # the staging directory for the openemr CVS package built in the packageServe
 # branch. Production default matches pre-refactor behavior.
@@ -318,12 +316,10 @@ do
   OPENEMR=$WEB/openemr
   FILESSERVEDIR=$WEB/files
   DOCKERDEMO=$DOCKERDEMOORIGINAL
-  FINALWEB=$WEB
  else
   DOCKERDEMO=${DOCKERDEMOORIGINAL}_${demo}
   OPENEMR=${WEB}/${demo}/openemr
   FILESSERVEDIR=$WEB/${demo}/files
-  FINALWEB=$WEB/${demo}
  fi
 
  # Collect ip address or docker demo number
@@ -456,13 +452,6 @@ IPADDRESS=$DOCKERDEMO
   randomTheme=false;
  else
   randomTheme=true;
- fi
- # set if doing password reset
- # (if 1, then will reset just admin, if 2, then will reset all the official demo users)
- if [ "$passReset" == "0" ]; then
-  passResetAuto=false;
- else
-  passResetAuto=true;
  fi
  # set if using a capsule
  if [ "$useCapsule" == "0" ]; then
@@ -854,10 +843,6 @@ IPADDRESS=$DOCKERDEMO
   echo "Done creating OpenEMR Development packages" >> $LOG
  fi
 
- #if $passResetAuto; then
-  # run the auto reset password script every 5 minutes
-  #nohup php -f ${PASSWORDRESETSCRIPT} ${FINALWEB} 300 ${passReset} >/dev/null 2>&1 &
- #fi
 done
 
 # Start Postfix for restarts, uses stunnel to communicate to aws ses email server.

--- a/demo_build.sh
+++ b/demo_build.sh
@@ -467,8 +467,13 @@ IPADDRESS=$DOCKERDEMO
  else
   randomTheme=true;
  fi
- # set if doing password reset
- # (if 1, then will reset just admin, if 2, then will reset all the official demo users)
+ # set if doing password reset. Modes mirror set_pass.php's $mode arg:
+ #   0 = disabled
+ #   1 = just admin, OpenEMR <6.0.0    } legacy; no current production
+ #   2 = all official users, <6.0.0    } demos run pre-6 anymore
+ #   3 = just admin, OpenEMR 6.0.0+
+ #   4 = all official users, 6.0.0+
+ # Production demos on demo.openemr.io (rows five/five_a/five_b) use mode 4.
  if [ "$passReset" == "0" ]; then
   # shellcheck disable=SC2034  # consumed by the commented-out password-reset block at end of loop; openemr/openemr#5991
   passResetAuto=false;

--- a/docker/scripts/primeLetsencrypt.sh
+++ b/docker/scripts/primeLetsencrypt.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 primeLetsencrypt

--- a/docker/scripts/renewLetsencrypt.sh
+++ b/docker/scripts/renewLetsencrypt.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 renewLetsencrypt

--- a/docker/scripts/restartDemo.sh
+++ b/docker/scripts/restartDemo.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 # Ensure have a correct demo name parameter

--- a/docker/scripts/restartMysql.sh
+++ b/docker/scripts/restartMysql.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 restartMysql

--- a/docker/scripts/restartNginx.sh
+++ b/docker/scripts/restartNginx.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 restartNginx

--- a/docker/scripts/restartPhp.sh
+++ b/docker/scripts/restartPhp.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 restartPhp

--- a/docker/scripts/restartPhpmyadmin.sh
+++ b/docker/scripts/restartPhpmyadmin.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 restartPhpmyadmin

--- a/docker/scripts/snapshotDemo.sh
+++ b/docker/scripts/snapshotDemo.sh
@@ -11,6 +11,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 # Ensure have a correct demo name parameter

--- a/docker/scripts/startFarm.sh
+++ b/docker/scripts/startFarm.sh
@@ -35,6 +35,7 @@
 #
 
 # Bring in the demo function library
+# shellcheck source=docker/scripts/demoLibrary.source
 source ~/demo_farm_openemr/docker/scripts/demoLibrary.source
 
 # to collect the standard docker images

--- a/tools/auto-derive/derive.sh
+++ b/tools/auto-derive/derive.sh
@@ -668,6 +668,7 @@ read_current_ip_map() {
         CUR_ROW["$cluster"]="$line"
         # split columns
         IFS=$'\t' read -ra cols <<< "$line"
+        # shellcheck disable=SC2034  # populated for parity with the documented CUR_* parser family (see L612); not currently consumed but kept for future derive logic
         CUR_REPO["$cluster"]="${cols[1]:-}"
         CUR_BRANCH["$cluster"]="${cols[2]:-}"
 
@@ -687,13 +688,11 @@ read_current_ip_map() {
 
     # Build alias map: for each base cluster X, list its _a / _b siblings.
     local c base
-    declare -gA seen_base=()
     for c in "${CUR_ORDER[@]}"; do
         case "$c" in
             *_a|*_b) ;;  # aliases handled via their base
             *)
                 base="$c"
-                seen_base["$base"]=1
                 local aliases=""
                 local cand
                 for cand in "${CUR_ORDER[@]}"; do
@@ -838,10 +837,6 @@ synth_master_row() {
     local cluster="$1" php="$2" alpine="$3"
     local with_data=0
     [[ "$cluster" == *_a ]] && with_data=1
-
-    local base_cluster="${cluster%_a}"
-    local subdomain="$base_cluster.openemr.io"
-    [[ "$cluster" == *_a ]] && subdomain="$base_cluster.openemr.io/a"
 
     # Description casing convention from current file: non-alias rows use
     # "on Alpine"; alias (_a) rows use "On Alpine". Preserved verbatim.


### PR DESCRIPTION
## Summary

PR **C1** of the ShellCheck ratchet cleanup. Drops `SC1090` + `SC2034` (~30 min of work). `SC2086` (the bulk) is split into C2 (covered files, ~127 sites) and C3 (uncovered files, ~80 sites in `demoLibrary.source`) for separate review.

## What changed

### SC1090 — 9 sites, mechanical fix

All 9 `docker/scripts/*.sh` drivers source `~/demo_farm_openemr/docker/scripts/demoLibrary.source`. ShellCheck can't follow a `~`-relative path at lint time. Added a `# shellcheck source=docker/scripts/demoLibrary.source` directive above each source line. **No behavior change.**

### SC2034 — 7 sites, audited each

#### `demo_build.sh` (4 sites — password-reset machinery, kept with inline disables)

The first cut of this PR deleted `PASSWORDRESETSCRIPT` / `FINALWEB` / `passResetAuto` and the commented-out re-enable block on the theory that they were dead. Walked that back after digging into the history:

- **`4e3a2ba` (Dec 2022)**: *"Temporarily disable the automated password reset feature in the demo farm since it is breaking the demos. Need to fix it at some point. See openemr/openemr#5991 for details."*
- **`a393d37` (Dec 2022)**: *"fix bug in prior commit. need to completely comment out the if block to temporarily stop the password reset mechanism"*

Corroborating evidence the feature is still expected to come back:

- `set_pass.php` (7KB CLI script with modes 1–4) is preserved in the repo root.
- `ip_map_branch.txt`'s `pass_reset` column is still actively populated for production rows — `demo.openemr.io` (rows `five`/`five_a`/`five_b`) carry `pass_reset=4` ("reset all official users on 6.0.0+"), encoding intent in the data even though the daemon isn't running.

So these variables are **feature-toggled off pending upstream bug fix**, not dead. The PR now:

- Restores `PASSWORDRESETSCRIPT` (L241), `FINALWEB` (L321 + L326), and the `passResetAuto` if/else block.
- Adds an inline `# shellcheck disable=SC2034` on each assignment, each referencing `openemr/openemr#5991`.
- Restores the commented-out `#if $passResetAuto; then #nohup ... #fi` block with a sharper header note that explicitly cites the upstream issue and tells future maintainers why each piece is still here.
- Keeps the variables wired up so re-enabling stays a one-line uncomment, not a rewrite.

**`GITTRANS` (4th demo_build.sh SC2034 site) is genuinely unused** — never referenced anywhere, no disable-pending-fix history attached. Deleted.

#### `tools/auto-derive/derive.sh` (3 sites)

| Var | Decision | Why |
| --- | --- | --- |
| `CUR_REPO` | **Keep**, inline disable | Part of the documented `CUR_*` parser family (declared alongside siblings at L624, comment at L612 names this column). Plausible future use. |
| `seen_base` | **Delete** | Marker written but never checked. The dedup safeguard it implied is a no-op (`CUR_ORDER` has no duplicates). |
| `subdomain` | **Delete** | Computed inside `synth_master_row` but never read. Vestigial. Also dropped the now-orphaned `base_cluster` local that fed it. |

## Verification

- `shellcheck --check-sourced --external-sources` repo-wide (excluding fixtures) — clean.
- `./tools/build-tests/test.sh` — 7/7 PASS.
- `./tools/auto-derive/fixtures-and-tests/test.sh` — 8/8 PASS.

Goldens are unchanged across the revision: the restored variable assignments don't emit any wrapped-command lines (no action-log changes).

## Commit history

1. `8ffc541` — original (SC1090 directives + initial SC2034 audit; included an over-eager password-reset deletion now reverted).
2. `7000fd3` — revision (restores `PASSWORDRESETSCRIPT` / `FINALWEB` / `passResetAuto` + the comment block with inline disables + `openemr/openemr#5991` reference; keeps `GITTRANS` deletion + derive.sh changes).

## State after this PR

3 disables remaining in `.shellcheckrc`:

- `SC2086` (175 sites) — split into **C2** (103 covered: `demo_build.sh` + `derive.sh`) and **C3** (72 uncovered: `demoLibrary.source`)
- `SC2006` (28 backticks) — folds into C2 (24 sites in `demo_build.sh`) and C3 (4 sites in `demoLibrary.source`)
- `SC2155` (4 sites, all in `demoLibrary.source`) — folds into C3

C3 is the one with high regression risk (same shape as the wkhtmltopdf bug in PR #150) and gets a separate strategy discussion before being started.

## The lesson worth keeping from the revision

The `seen_base` / `subdomain` deletions were both safe — those vars were truly stranded with no history of intent. The `PASSWORDRESETSCRIPT` family looked the same on the surface (write-only, only referenced by a commented-out block) but had **load-bearing intent encoded in the git history and in adjacent data** (the `pass_reset` ip_map column). "Apparently unused" findings from shellcheck need the full archaeology when there's any sign the surrounding region is feature-flagged off rather than retired — comment-block adjacency is one signal, ip_map column still populated is another, an existing script file in the repo root that's only referenced from one place is a third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
