### PR TITLE
ci(shellcheck): drop SC2155 + clear SC2006 in demoLibrary.source (C3a)

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -12,6 +12,3 @@
 # cleaned up. This repo isn't there yet.
 
 external-sources=true
-
-# Pre-existing bash warnings deferred to follow-up cleanup PRs.
-disable=SC2155  # declare and assign separately (4 violations) -- masks return values

--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -9,12 +9,13 @@
 #
 # Bash library for openemr demo farm
 #
-# Per-file shellcheck ratchet (issue #146 cleanup PR C2): the 80 SC2086 /
-# SC2006 / SC2155 violations in this file are deferred to PR C3. The
-# file-level disable here lets C2's drop of the repo-wide SC2086 +
-# SC2006 disables land cleanly; C3 will fix each site individually and
-# remove this directive.
-# shellcheck disable=SC2086,SC2006,SC2155
+# Per-file shellcheck ratchet (issue #146 cleanup, post-C2 + C3a):
+# the 72 SC2086 violations in this file remain deferred to PR C3b.
+# C3a closed out SC2006 (4 sites) and SC2155 (4 sites — surfaced after
+# SC2006 fix at the same code positions, same masked-warning pattern
+# as C2's SC2002 fold-in). C3b will fix each SC2086 site individually
+# and remove this directive.
+# shellcheck disable=SC2086
 
 # This is the wrapper to start the demo, so only need to modify the specifics in 1 place
 # rather than 2. Picks the right flex image + instance count per cluster, then
@@ -87,7 +88,8 @@ startDemoWrapper() {
 # 1st parameter is the demo name (one, two, three, etc.)
 # 2nd parameter is the mysql root password
 stopDemo () {
-    local MYSQLIP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr`
+    local MYSQLIP
+    MYSQLIP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr)
 
     # Stop the docker
     echo "Stop ${1}-openemr docker"
@@ -158,7 +160,8 @@ startDemo () {
 # 2nd parameter is the demo subname (a, b, c, etc.)(also can be 'empty' which is for the main subdemo)
 # 3rd parameter is the mysql root password
 restartSubdemo () {
-    local MYSQLIP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr`
+    local MYSQLIP
+    MYSQLIP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr)
 
     # Remove the database stuff
     if [ "$2" == "empty" ]; then
@@ -280,8 +283,10 @@ renewLetsencrypt () {
 # 2nd parameter is the demo subname (a, b, c, etc.)(also can be 'empty' which is for the main subdemo)
 # 3rd parameter is the mysql root password
 snapshotDemo() {
-    local MYSQLIP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr`
-    local currentTime=`date "+%Y-%m-%d-%H-%M-%S"`
+    local MYSQLIP
+    MYSQLIP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql-openemr)
+    local currentTime
+    currentTime=$(date "+%Y-%m-%d-%H-%M-%S")
     local snapshotName="${1}-${2}-${currentTime}"
     local capsules=~/capsules
     local tmp="${capsules}/tmp"


### PR DESCRIPTION
## Summary

PR **C3a** of the ratchet cleanup. Closes out `SC2006` (rc-wide) and `SC2155` (file-level) for `docker/scripts/demoLibrary.source`. `SC2086` in this file is C3b's bulk audit (in flight as a parallel PR); the file-level disable is trimmed from `SC2086,SC2006,SC2155` → `SC2086`.

## What changed

### `SC2006` (4 sites, mechanical)

| Line | Pattern |
| --- | --- |
| 91, 162, 284 | `local MYSQLIP=`docker inspect …`` |
| 285 | `local currentTime=`date "+…"`` |

All converted to `$(...)` form.

### `SC2155` (4 sites, surfaced after the SC2006 fix)

Same code positions as the SC2006 fix. Once the backticks became `$(…)`, ShellCheck's "`local x=$(cmd)` masks return value" finding became visible. **Same masked-warning pattern as the SC2002 fold-in in C2** — one warning per code position, the louder one (SC2006 in this case) wins until it's resolved.

Fix: split into two statements (declare separately, then assign). Now if `docker inspect` or `date` fails, the assignment carries the real exit code instead of being masked by `local`'s exit code:

```bash
# before
local MYSQLIP=$(docker inspect -f '{{...}}' mysql-openemr)

# after
local MYSQLIP
MYSQLIP=$(docker inspect -f '{{...}}' mysql-openemr)
```

**Note on the rc estimate**: the comment said `"(4 violations)"` for SC2155 but ShellCheck only reported 0 with SC2006 still active. The 4 became visible after C3a's SC2006 fix unmasked them. Estimate matched the actual count exactly (4) — the comment was right, the count just wasn't reachable until SC2006 was cleaned.

### `.shellcheckrc`

`SC2155` disable dropped — was the only remaining repo-wide disable. The rc file now has zero `disable=` lines.

### File-level directive on `demoLibrary.source`

Trimmed from `# shellcheck disable=SC2086,SC2006,SC2155` to `# shellcheck disable=SC2086`. C3b will remove the directive entirely once the 72 SC2086 sites are individually fixed.

## Verification

- `shellcheck --check-sourced --external-sources` repo-wide (excluding fixtures) — clean.
- `./tools/build-tests/test.sh` — 7/7 PASS.
- `./tools/auto-derive/fixtures-and-tests/test.sh` — 8/8 PASS.

## Coordination with C3b

C3b is in flight as a parallel PR (it handles the 72 remaining SC2086 sites in `demoLibrary.source`). Both PRs touch the same file-level `# shellcheck disable=...` line — whichever lands second rebases on the first and re-applies its directive edit. Mechanical conflict, not behavioral.

## State after this PR

- `.shellcheckrc`: empty of `disable=` lines (only `external-sources=true` remains).
- `demoLibrary.source`: file-level `# shellcheck disable=SC2086` directive remains pending C3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shell-checking settings to allow more accurate validation and reduce over-suppressed warnings.
  * Modernized shell command usage in maintenance scripts for more consistent behavior.
  * Improved timestamp and value assignment handling in demo-related workflows without changing expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->