### PR TITLE
fix(demo_build): append light-reset demo name to $LOG (closes #153)

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -274,7 +274,7 @@ if $lightReset; then
  echo -n "subdemo reset mode for: "
  echo "$lightResetDemo"
  echo -n "subdemo reset mode for: " >> "$LOG"
- echo "$lightResetDemo"
+ echo "$lightResetDemo" >> "$LOG"
 elif [ "$DOCKERNUMBERDEMOS" == "10" ]; then
  demosGo=("empty" "a" "b" "c" "d" "e" "f" "g" "h" "i")
  echo "10 demos mode"


### PR DESCRIPTION
Closes #153. One-line fix: adds the missing `>> "$LOG"` redirect on the light-reset subdemo-name echo so the persistent log gets the value instead of just the prefix.

## Test plan

- [x] `bash -n demo_build.sh` clean
- [x] `shellcheck` clean
- [x] `./tools/build-tests/test.sh` — 7/7 PASS

The dry-run goldens are unaffected — action-log emissions don't include $LOG writes, so this changes runtime behavior but not any captured golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo build logging in `--lightReset` mode so the `lightResetDemo` value is now recorded in the build log instead of only being printed to the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->