### PR TITLE
fix(demoLibrary): use MYSQL_PWD env var instead of -p<pass> cmdline (closes #158)

### DIFF
--- a/docker/scripts/demoLibrary.source
+++ b/docker/scripts/demoLibrary.source
@@ -90,26 +90,26 @@ stopDemo () {
 
     # Remove the database stuff
     echo "Clear ${1}-openemr databases and users"
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_a
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_b
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_c
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_d
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_e
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_f
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_g
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_h
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"_i
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_a';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_b';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_c';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_d';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_e';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_f';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_g';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_h';FLUSH PRIVILEGES;"
-    mysql -f -h "${MYSQLIP}" -u root -p"${2}" -e "DROP USER '${1}_i';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_a
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_b
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_c
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_d
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_e
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_f
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_g
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_h
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_i
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_a';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_b';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_c';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_d';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_e';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_f';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_g';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_h';FLUSH PRIVILEGES;"
+    MYSQL_PWD="${2}" mysql -f -h "${MYSQLIP}" -u root -e "DROP USER '${1}_i';FLUSH PRIVILEGES;"
 }
 
 # Will start an openemr demo
@@ -157,9 +157,9 @@ restartSubdemo () {
 
     # Remove the database stuff
     if [ "$2" == "empty" ]; then
-        mysqladmin -f -h "${MYSQLIP}" -u root -p"${3}" drop "${1}"
+        MYSQL_PWD="${3}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"
     else
-        mysqladmin -f -h "${MYSQLIP}" -u root -p"${3}" drop "${1}"_"${2}"
+        MYSQL_PWD="${3}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"_"${2}"
     fi
 
     # Now need to reset the demo within the docker
@@ -292,11 +292,11 @@ snapshotDemo() {
     mkdir -p "${tmpPath}"
     if [ "$2" == "empty" ]; then
         echo "snapshot of empty subname (ie. the one without a letter)"
-        mysqldump --ignore-table="${1}".onsite_activity_view --hex-blob -u root -p"${3}" -h "${MYSQLIP}" "${1}" > "${tmpPath}/backup.sql"
+        MYSQL_PWD="${3}" mysqldump --ignore-table="${1}".onsite_activity_view --hex-blob -u root -h "${MYSQLIP}" "${1}" > "${tmpPath}/backup.sql"
         docker cp "${1}-openemr:/var/www/localhost/htdocs/openemr/sites" "${tmpPath}"
     else
         echo "snapshot of non-empty subname (ie. with a letter)"
-        mysqldump --ignore-table="${1}"_"${2}".onsite_activity_view --hex-blob -u root -p"${3}" -h "${MYSQLIP}" "${1}"_"${2}" > "${tmpPath}/backup.sql"
+        MYSQL_PWD="${3}" mysqldump --ignore-table="${1}"_"${2}".onsite_activity_view --hex-blob -u root -h "${MYSQLIP}" "${1}"_"${2}" > "${tmpPath}/backup.sql"
         docker cp "${1}-openemr:/var/www/localhost/htdocs/${2}/openemr/sites" "${tmpPath}"
     fi
     cd "${tmp}" || return 1


### PR DESCRIPTION
Closes #158. Rewrites 24 mariadb call sites in `demoLibrary.source` to pass the root password via `MYSQL_PWD` env instead of `-p<pass>` argv, keeping the credential out of `ps` output.

## Sites rewritten (24 total)

- `stopDemo()` — 10 `mysqladmin drop` + 10 `mysql DROP USER` (20)
- `restartSubdemo()` — 2 `mysqladmin drop` (2)
- `snapshotDemo()` — 2 `mysqldump` (2)

Uniform pattern:

```diff
-    mysqladmin -f -h "${MYSQLIP}" -u root -p"${2}" drop "${1}"
+    MYSQL_PWD="${2}" mysqladmin -f -h "${MYSQLIP}" -u root drop "${1}"
```

## Current real-world risk

Low — same reasoning as #155. Every production row has `root_sql_pass = hey`, matching `MYSQL_ROOT_PASSWORD=hey` in `demoLibrary.source:174`. Value isn't a secret. Defense-in-depth for the day someone sets a real password.

MYSQL_PWD is still visible via `/proc/<pid>/environ`, but that requires the same host access as `ps`. Not worse than the pre-fix scope. If `/proc/environ` exposure needs to be closed too, the follow-up is `--defaults-file=<mktemp with 0600>`.

## Test plan

- [x] `shellcheck --check-sourced --external-sources` clean
- [x] `bash -n` clean
- [x] Auto-derive fixture suite (parses `demoLibrary.source`'s `startDemoWrapper` case block) — 8/8 PASS

Related: #160 (companion PR for $LOG-file leak in `demo_build.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)