### PR TITLE
fix(demo_build): anchor ip_map lookup via awk field match (closes #154)

### DIFF
--- a/demo_build.sh
+++ b/demo_build.sh
@@ -343,9 +343,22 @@ echo -n "Docker Demo is " >> "$LOG"
 echo "$DOCKERDEMO" >> "$LOG"
 IPADDRESS=$DOCKERDEMO
 
+ # Look up this iteration's ip_map row exactly once. Using awk with an
+ # anchored `$1 == ip` field match rather than `grep "$IPADDRESS"` --
+ # the substring grep would also match sibling rows (e.g., IPADDRESS
+ # "two" matched both the "two" and "two_a" rows, then the downstream
+ # `tr -d '\n' | cut -f N` concatenated both and pulled the wrong
+ # field). `exit` after first match makes the lookup unambiguous even
+ # if the map ever has a duplicate key.
+ map_row=$(awk -F$'\t' -v ip="$IPADDRESS" '$1 == ip { print; exit }' "$GITDEMOFARMMAP")
+ if [ -z "$map_row" ]; then
+  echo "ERROR: no demo-map entry for '$IPADDRESS' in $GITDEMOFARMMAP" | tee -a "$LOG" >&2
+  exit 1
+ fi
+
  # COLLECT MAPPED BRANCH AND OPTIONS
  # Grab repo link
- OPENEMRREPO=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 2)
+ OPENEMRREPO=$(printf '%s\n' "$map_row" | cut -f 2)
  echo -n "git repo is "
  echo "$OPENEMRREPO"
  echo -n "git repo is " >> "$LOG"
@@ -367,40 +380,40 @@ IPADDRESS=$DOCKERDEMO
  echo -n "git repo local path is " >> "$LOG"
  echo "$GIT" >> "$LOG"
  # Grab branch
- GITBRANCH=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 3)
+ GITBRANCH=$(printf '%s\n' "$map_row" | cut -f 3)
  echo -n "git branch is "
  echo "$GITBRANCH"
  echo -n "git branch is " >> "$LOG"
  echo "$GITBRANCH" >> "$LOG"
  # Grab use development translation set option
- udt=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 5)
+ udt=$(printf '%s\n' "$map_row" | cut -f 5)
  echo -n "udt option is "
  echo "$udt"
  echo -n "udt option is " >> "$LOG"
  echo "$udt" >> "$LOG"
  # Grab serve packages option
- sp=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 6)
+ sp=$(printf '%s\n' "$map_row" | cut -f 6)
  echo -n "sp option is "
  echo "$sp"
  echo -n "sp option is " >> "$LOG"
  echo "$sp" >> "$LOG"
  # Grab demo data option
- dd=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 8)
+ dd=$(printf '%s\n' "$map_row" | cut -f 8)
  echo -n "dd option is "
  echo "$dd"
  echo -n "dd option is " >> "$LOG"
  echo "$dd" >> "$LOG"
- ppapi=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 10)
+ ppapi=$(printf '%s\n' "$map_row" | cut -f 10)
  echo -n "ppapi option is "
  echo "$ppapi"
  echo -n "ppapi option is " >> "$LOG"
  echo "$ppapi" >> "$LOG"
- EXTERNALLINK=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 11)
+ EXTERNALLINK=$(printf '%s\n' "$map_row" | cut -f 11)
  echo -n "external link is "
  echo "$EXTERNALLINK"
  echo -n "external link is " >> "$LOG"
  echo "$EXTERNALLINK" >> "$LOG"
- mrp=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 12)
+ mrp=$(printf '%s\n' "$map_row" | cut -f 12)
  # Log presence, not the value: $LOG is exposed at <cluster>.openemr.io/log/
  # via the demo dockers (see L226-235 header comment), so writing the actual
  # password would bake it into a publicly-accessible URL. Current $mrp is
@@ -415,22 +428,22 @@ IPADDRESS=$DOCKERDEMO
  # col 13 (branch_tag) is deprecated; col position preserved with value "0".
  # demo_build.sh no longer reads it -- the clone below uses
  # `git clone --branch <ref> --depth 1` which works for both branches and tags.
- ddu=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 14)
+ ddu=$(printf '%s\n' "$map_row" | cut -f 14)
  echo -n "ddu option is "
  echo "$ddu"
  echo -n "ddu option is " >> "$LOG"
  echo "$ddu" >> "$LOG"
- funStuff=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 15)
+ funStuff=$(printf '%s\n' "$map_row" | cut -f 15)
  echo -n "funStuff option is "
  echo "$funStuff"
  echo -n "funStuff option is " >> "$LOG"
  echo "$funStuff" >> "$LOG"
- passReset=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 16)
+ passReset=$(printf '%s\n' "$map_row" | cut -f 16)
  echo -n "passReset option is "
  echo "$passReset"
  echo -n "passReset option is " >> "$LOG"
  echo "$passReset" >> "$LOG"
- useCapsule=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 17)
+ useCapsule=$(printf '%s\n' "$map_row" | cut -f 17)
  echo -n "useCapsule option is "
  echo "$useCapsule"
  echo -n "useCapsule option is " >> "$LOG"
@@ -497,7 +510,7 @@ IPADDRESS=$DOCKERDEMO
  fi
 
  # COLLECT and output demo description
- desc=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 18)
+ desc=$(printf '%s\n' "$map_row" | cut -f 18)
  echo -n "Demo description: "
  echo "$desc"
  echo -n "Demo description: " >> "$LOG"

--- a/tools/build-tests/test.sh
+++ b/tools/build-tests/test.sh
@@ -10,11 +10,14 @@
 #                                   DOCKERNUMBERDEMOS, PHP_VERSION_ABBR,
 #                                   EXTRA_ARGS (appended after --dry-run).
 #   ip_map_branch.txt            -- the ip_map subset the script will read.
-#                                   Should contain ONLY the row(s) needed
-#                                   for this scenario to avoid the
-#                                   grep "$IPADDRESS" substring-match
-#                                   ambiguity (e.g., "two" matches both
-#                                   "two" and "two_a" rows).
+#                                   Historically had to be single-row to
+#                                   dodge the grep "$IPADDRESS" substring
+#                                   ambiguity ("two" matched "two_a" too);
+#                                   demo_build.sh now uses an anchored
+#                                   `awk '$1 == ip'` lookup so multi-row
+#                                   fixtures are fine. Existing fixtures
+#                                   stay single-row -- changing them would
+#                                   be churn without adding coverage.
 #   extra/                       -- (optional) tree of files copied OVER
 #                                   the kitchen-sink work tree post-setup,
 #                                   mirroring its layout (the work tree


### PR DESCRIPTION
Closes #154. Refactors the 13 per-column extractions in the `demosGo` loop body to do one anchored `$1 == ip` row lookup via `awk`, then read each field from the captured row.

## Bug

The previous pattern

```bash
grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f N
```

is a substring match. `IPADDRESS=two` matched both the `two` row AND the `two_a` row; `tr -d '\n'` concatenated them; `cut -f N` pulled field N from the joined text — almost always the wrong value.

In production this affects every row whose `docker_number` is a substring of another active row: `two`/`two_a`, `four`/`four_a`/`four_b`, `five`/`five_a`/`five_b`, etc.

The build-tests fixture harness carried single-row map files expressly as a workaround (see `tools/build-tests/test.sh:14-17`).

## Fix

```diff
+ map_row=$(awk -F$'\t' -v ip="$IPADDRESS" '$1 == ip { print; exit }' "$GITDEMOFARMMAP")
+ if [ -z "$map_row" ]; then
+  echo "ERROR: no demo-map entry for '$IPADDRESS' in $GITDEMOFARMMAP" | tee -a "$LOG" >&2
+  exit 1
+ fi
- OPENEMRREPO=$(grep "$IPADDRESS" "$GITDEMOFARMMAP" | tr -d '\n' | cut -f 2)
+ OPENEMRREPO=$(printf '%s\n' "$map_row" | cut -f 2)
```

13 extractions rewritten to the `printf '%s\n' "$map_row" | cut -f N` shape.

## Test plan

- [x] `./tools/build-tests/test.sh` — 7/7 PASS. (Fixtures use single-row map files so both implementations produce identical output; validates no downstream shift.)
- [x] `shellcheck` clean
- [x] `bash -n` clean

## Not in scope

- Adding fixtures for the multi-row ambiguity case now that the fix is in. Was previously untestable.
- Reworking the fixture harness comment that documents the workaround (it's still accurate for the previous state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
