### PR TITLE
docs(readme): modernize + add workflow status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,84 @@
-The repo holds the mechanism for an OpenEMR demo farm.
+# demo_farm_openemr
 
-The farm is docker-based. See docker/scripts/startFarm.sh for the entry point.
+[![ShellCheck](https://github.com/openemr/demo_farm_openemr/actions/workflows/shellcheck.yml/badge.svg?branch=master)](https://github.com/openemr/demo_farm_openemr/actions/workflows/shellcheck.yml)
+[![build-tests (dry-run)](https://github.com/openemr/demo_farm_openemr/actions/workflows/build-tests.yml/badge.svg?branch=master)](https://github.com/openemr/demo_farm_openemr/actions/workflows/build-tests.yml)
+[![build-tests (live integration)](https://github.com/openemr/demo_farm_openemr/actions/workflows/build-tests-live.yml/badge.svg?branch=master)](https://github.com/openemr/demo_farm_openemr/actions/workflows/build-tests-live.yml)
+[![Derive ip_map (reconcile)](https://github.com/openemr/demo_farm_openemr/actions/workflows/derive-ip-map.yml/badge.svg?branch=master)](https://github.com/openemr/demo_farm_openemr/actions/workflows/derive-ip-map.yml)
 
-How do I set one of the "UP FOR GRABS" OpenEMR demos?
------------------------------------------------------
-1. Fork the https://github.com/openemr/demo_farm_openemr.git repo and make it your own
-2. Place your OpenEMR git repo information in the openemr_repo and branch items in
-   your ip_map_branch.txt for one of the UP FOR GRABS demo entries (`four`, `four_a`, or `four_b`).
-3. Place a github pull request on your commit for number 2 above.
-4. After I bring in your github pull request, then place your repo and branch
-   information in the pertinent UP FOR GRABS demo entries here:
-   https://www.open-emr.org/wiki/index.php/Development_Demo#UP_FOR_GRABS_Development_Demos
-5. When the demo resets (which is daily), it will now be using your selected repo branch!!
+Mechanism for the OpenEMR demo farm at [demo.openemr.io](https://demo.openemr.io) and its sibling clusters (`one.openemr.io`, `two.openemr.io`, `three.openemr.io`, etc.).
 
-Description of ip_map_branch.txt configuration file
----------------------------------------------------
-This file is a tab delimited file for configuration of demos in the demo farm with following settings:
-- docker_number: docker name of the OpenEMR demo
-- openemr_repo: set it to the openemr repo you want to grab code from
-- branch: git branch of the OpenEMR github repository
-- serve_development_translations(not used): unused; column kept for backward column-order compatibility.
-- use_development_translations: set to 1 to have demo use the daily build of translation set, set to 0 to turn this off
-- serve_packages: set to 1 to have demo serve zip/tgz packages of the build for download, set to 0 to turn this off
-- legacy_patching(not used): unused; column kept for backward column-order compatibility.
-- demo_data: set to 0 if no sql demo data file. If have a sql demo data file, then place the name of it here and place the file in the 'pieces' directory.
-- demo_ssh(not used): unused; column kept for backward column-order compatibility.
-- patient_portals_and_api: set to 0 to not use. Set to 1 to enable the onsite patient portal demo and the REST / FHIR / OAuth APIs.
-- external_link: place the external web address to the demo here
-- root_sql_pass: set the root_sql_pass to use.
-- branch_tag: set this to `branch` when using a github branch and `tag` when using a github tag. 
-- demo_data_upgrade_from: when set demo_data above or capsule below, then place the OpenEMR version that the demo data was based on (so it will then be upgraded from that version).
-- fun_stuff: set this to randomly select a theme. Set to 0 to turn off. Set to 1 for when using OpenEMR version < 6.0 and set to 2 when using OpenEMR version 6.0 and greater.
-- pass_reset: set this to have password(s) reset to default every 5 minutes. Set to 0 to turn off. Set to 1 for demos that just have admin user. Set to 2 for demos that have the standard demo data.
-- capsule: set to 0 if no capsule. If have a capsule, then place the name of it here.
-- description: place description of the demo here
+The farm is docker-based, running on a single EC2 instance. Each cluster is one `openemr/openemr:flex-<alpine>-php-<n>` container that runs `demo_build.sh` at startup to clone one or more OpenEMR git refs into that container's web root. `docker/scripts/startFarm.sh` is the initial-provisioning entry point; `restartFarm.sh` is what the daily 08:00 UTC cron fires to reset all demos back to a clean state.
 
-How to restart the demo farm when the instance does a shutdown/reboot
-----------------------------------------------------------------
-- Step 1 : First start the following dockers via commmands below
-    ```sh
-    bash ~/demo_farm_openemr/docker/scripts/restartMysql.sh
-    bash ~/demo_farm_openemr/docker/scripts/restartPhpmyadmin.sh
-    bash ~/demo_farm_openemr/docker/scripts/restartPhp.sh
-    ```
-- Step 2 : Then start the nginx (reverse-proxy) docker via command below
-    ```sh
-    bash ~/demo_farm_openemr/docker/scripts/restartNginx.sh
-    ```
-- Step 3 : Do a demo farm reset (this will start up all the openemr dockers; same things that happens every night during a farm reset)
-    ```sh
-    bash ~/demo_farm_openemr/docker/scripts/restartFarm.sh
-    ```
-- Step 4: Wait for the reset (ie. magic) to happen. Recommend drinking a cup of coffee and watching the following video about 15 times: https://www.youtube.com/watch?v=JnbfuAcCqpY
+## How do I set one of the "UP FOR GRABS" OpenEMR demos?
 
-LICENSE
---------------------------------------
-GNU GENERAL PUBLIC LICENSE
+1. Fork this repo.
+2. Update the `openemr_repo` and `branch` columns in `ip_map_branch.txt` for one of the UP FOR GRABS entries (`four`, `four_a`, or `four_b`).
+3. Open a pull request with the change.
+4. Once merged, also update the pertinent entry on the [Development Demo wiki page](https://www.open-emr.org/wiki/index.php/Development_Demo#UP_FOR_GRABS_Development_Demos).
+5. At the next daily reset (08:00 UTC), the demo will pick up your selected repo/branch.
+
+## `ip_map_branch.txt` columns
+
+Tab-delimited. Each row configures one cluster (`docker_number` without underscore) or one subdemo within a cluster (`docker_number` with `_<letter>` suffix). The header row itself annotates deprecated columns with `(not used)` so the schema is self-describing.
+
+| # | Column | Notes |
+| --- | --- | --- |
+| 1 | `docker_number` | Cluster or subdemo id — `two`, `five`, `two_a`, `four_b`, etc. Also the mariadb database name. |
+| 2 | `openemr_repo` | Full git URL to clone. Usually `https://github.com/openemr/openemr.git`; UP FOR GRABS entries can point at forks. |
+| 3 | `branch` | Git ref to clone — branch name (`master`, `rel-810`) or tag name (`v8_0_0_3`). `demo_build.sh` uses `git clone --branch <ref> --depth 1` which accepts both. |
+| 4 | `serve_development_translations` | Deprecated. Column preserved for backward column-order compatibility. |
+| 5 | `use_development_translations` | `1` = use the daily-built translation set, `0` = use the checked-in one. |
+| 6 | `serve_packages` | `1` = also build and serve OpenEMR CVS `.tar.gz` and `.zip` packages under `<cluster>.openemr.io/files/` (a second composer + npm + phing pass in a staging dir; adds several minutes). `0` = skip. |
+| 7 | `legacy_patching` | Deprecated. Column preserved. |
+| 8 | `demo_data` | `0` = no demo data. Non-zero = filename of a `.sql` file under `pieces/` to load *after* `InstallerAuto.php` runs (drops the empty schema InstallerAuto created, then reloads from the file). |
+| 9 | `demo_ssh` | Deprecated. Column preserved. |
+| 10 | `patient_portals_and_api` | `1` = enable onsite patient portal + REST / FHIR / OAuth APIs by setting the corresponding `globals`. `0` = leave defaults. |
+| 11 | `external_link` | External web address for this demo. Used to set the `site_addr_oath` global (drives OAuth callback URLs). |
+| 12 | `root_sql_pass` | mariadb root password to authenticate to `MYSQL_ROOT_PASSWORD` on the mariadb container (`hey` in the production farm). |
+| 13 | `branch_tag` | Deprecated. Old-style branch-vs-tag switch; `git clone --branch` handles both, so `demo_build.sh` no longer reads this column. Set to `0`. |
+| 14 | `demo_data_upgrade_from` | If `demo_data` or `capsule` is set: OpenEMR version the data was originally captured against, so `sql_upgrade.php` can upgrade it forward to the running version. |
+| 15 | `fun_stuff` | Random-theme picker. `0` = off, `1` = 36-theme picker (older CSS themes), `2` = 6-theme picker (newer themes). **Any other non-zero value falls through to the 36-theme picker** (see `demo_build.sh`'s `if [ "$funStuff" == "2" ]; then ... else ... fi`). |
+| 16 | `pass_reset` | Historically drove `set_pass.php` to reset user passwords every 5 min. Documented modes 1/2 in older commits are stale — `set_pass.php` actually supports **1, 2, 3, 4** (3/4 are the 6.0.0+ variants of 1/2). Production rows use `4`. **The mechanism is currently disabled** pending [openemr/openemr#5991](https://github.com/openemr/openemr/issues/5991); see the commented-out invocation near the bottom of `demo_build.sh`'s per-iteration loop. Column values are kept aligned with intended future re-enable. |
+| 17 | `capsule` | `0` = no capsule. Non-zero = filename (without `.tgz`) of a capsule under `capsules/` to unpack over the OpenEMR install. See `demo_build.sh`'s `useCapsuleBoolean` branch. Values are validated against a path-traversal guard (`case "$useCapsuleFile" in '' \| */* \| . \| ..)`) added in #145. |
+| 18 | `description` | Free-form human description of this row. Surfaces in the setup log. |
+
+## How to restart the demo farm after a host reboot
+
+1. Bring up the shared infrastructure containers:
+   ```sh
+   bash ~/demo_farm_openemr/docker/scripts/restartMysql.sh
+   bash ~/demo_farm_openemr/docker/scripts/restartPhpmyadmin.sh
+   bash ~/demo_farm_openemr/docker/scripts/restartPhp.sh
+   ```
+2. Bring up the reverse-proxy container:
+   ```sh
+   bash ~/demo_farm_openemr/docker/scripts/restartNginx.sh
+   ```
+3. Do a full demo-farm reset (this is what the daily 08:00 UTC cron runs):
+   ```sh
+   bash ~/demo_farm_openemr/docker/scripts/restartFarm.sh
+   ```
+4. Wait. Full reset takes roughly an hour end-to-end; the longest single step is the "cluster `five`" build (demo data + upgrade + random theme).
+
+## Regression tests (issue #146)
+
+`demo_build.sh` has two layers of automated regression coverage that fire in CI on every PR touching it (plus a nightly schedule for the live layer):
+
+- **Dry-run suite** — `tools/build-tests/`. Runs `demo_build.sh --dry-run` against 7 canned fixtures and diffs the captured action log against a per-fixture golden. Catches parsing, branching, and quoting regressions at PR time. Wall time: seconds.
+- **Live integration matrix** — `tools/build-tests/integration/`. Stands up a real `mariadb:10.6` + `openemr/openemr:flex` container per scenario and runs `demo_build.sh` end-to-end (composer + npm + webpack + `InstallerAuto.php` + apache start). 3 scenarios run in parallel via matrix; wall time ~10 min (slowest cell). Runs on every PR + daily 08:00 UTC schedule.
+
+The auto-derive bot also has its own fixture suite — `tools/auto-derive/fixtures-and-tests/` — 8 fixtures covering the parser + reconciler.
+
+## Auto-derive bot
+
+`tools/auto-derive/derive.sh` reconciles `ip_map_branch.txt` and `docker/scripts/demoLibrary.source` against the current upstream `openemr/openemr` release-targets + Dockerfiles. Runs daily at 07:00 UTC (workflow `.github/workflows/derive-ip-map.yml`) and opens a PR against master when it finds drift. If the drift disappears (upstream reverts), the open PR is closed automatically the next day.
+
+The bot also fires on `repository_dispatch types=release-targets-changed` — openemr/openemr triggers this whenever `.github/release-targets.yml` is pushed to master, so reconciliation is immediate rather than waiting for the next tick.
+
+## ShellCheck
+
+The repo is ShellCheck-clean. `.shellcheckrc` intentionally carries no `disable=` lines. `.github/workflows/shellcheck.yml` fires on any `.sh` / `.source` change and blocks merge on new violations. Historical ratchet cleanup: PRs #149 → #157.
+
+## License
+
+[GNU GPL v3](LICENSE).


### PR DESCRIPTION
## Summary

Rewrite of the README to reflect current demo_farm reality — several years' worth of work (auto-derive bot, build-tests suite, ShellCheck ratchet cleanup) had never made it into the README.

## What's new

**Workflow badges at the top** (per your request):

- ShellCheck (currently: rc has zero `disable=` lines)
- build-tests (dry-run) — per-PR fixture suite from #147
- build-tests (live integration) — nightly + per-PR matrix from #148
- Derive ip_map (reconcile) — auto-derive bot from #135

**Column docs corrected** (previous docs had drift from current code):

| Column | Fix |
| --- | --- |
| `branch_tag` | Moved to deprecated. Matches the header row's `(not used)` annotation + `demo_build.sh` comment + production data (all `0`). |
| `fun_stuff` | Documented actual code behavior: `1` = 36-theme picker, `2` = 6-theme picker, any other non-zero value falls through to the 36-theme picker. Previous phrasing ("1 for <6.0, 2 for 6.0+") read like a version gate. |
| `pass_reset` | Documented that `set_pass.php` actually supports modes 1-4 (3/4 are 6.0.0+ variants), production uses `4`, AND that the mechanism is currently disabled pending [openemr/openemr#5991](https://github.com/openemr/openemr/issues/5991). Previous docs still described modes 1/2 as if they were the whole set. |
| `capsule` | Added the path-traversal guard note (added by #145). |

Format changed from bullet list to table for readability.

**New sections:**

- Regression tests (dry-run suite + live matrix + auto-derive fixtures)
- Auto-derive bot (including the release-targets-changed cross-repo dispatch)
- ShellCheck (notes clean state + historical ratchet #149 → #157)

**Kept from previous README:**

- "UP FOR GRABS" onboarding steps (5-step process is still current)
- "How to restart the demo farm after a host reboot" (order + scripts still current). Trimmed the "watch this YouTube video 15 times" line since it dated the page.
- License

Intro paragraph rewritten to name the actual URL structure (demo.openemr.io etc.) and describe what a cluster/subdemo is, instead of the previous single-line description.

## Notes

- Fact-checks were against current `demo_build.sh`, `ip_map_branch.txt` header, `set_pass.php`, and workflow files. Anywhere the previous README disagreed with the code, I went with the code.
- Table + badges use standard GFM; no external dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
