### PR TITLE
ci(claude-review): drop pull_request trigger from caller

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,10 +6,8 @@
 name: Claude PR Review
 
 on:
-  pull_request:
-    types: [opened]        # auto-review non-bot PRs on open
   issue_comment:
-    types: [created]       # maintainers force a review with "@claude review"
+    types: [created]       # maintainer comments "@claude review" on a PR
 
 jobs:
   call-review:


### PR DESCRIPTION
## Summary

Companion caller update to the reusable-workflow change in openemr/openemr (see the linked PR there for full context).

The reusable workflow now only responds to `@claude review` comments — the `pull_request: opened` auto-trigger has been dropped in favor of on-demand-only invocation. This caller doesn't need to forward `pull_request` events anymore; keeping the trigger would cost a few Actions minutes per opened PR for a job that is guaranteed to skip inside the reusable's `if:` guard.

## Test plan

- [ ] Merge after the openemr/openemr reusable PR merges.
- [ ] Comment `@claude review` on any open PR here to confirm the workflow still fires end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)