### PR TITLE
chore(coderabbit): add config, skip auto-review on bot-authored PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+reviews:
+  high_level_summary: false
+  auto_review:
+    # Skip auto-review on PRs opened by these bots. Human maintainers can
+    # still opt-in per PR by commenting "@coderabbitai review" when a bot
+    # PR warrants a look (e.g., a suspicious dependency bump).
+    ignore_usernames:
+      - dependabot[bot]
+      - github-actions[bot]


### PR DESCRIPTION
## Summary

Adds a `.coderabbit.yaml` mirroring the config landed in openemr/openemr#12706. Turns off `high_level_summary` and adds `auto_review.ignore_usernames` for the bot accounts that open PRs here.

## Bot volume (last 30 days)

| Bot | Count |
|---|---|
| `dependabot[bot]` | 1 |
| `github-actions[bot]` | 1 |

Low volume, but the pattern is worth codifying now — both accounts are workflow-driven and the diffs are almost always mechanical.

## Escape hatch

Any maintainer can still invoke CodeRabbit on a bot PR by commenting `@coderabbitai review`.

## Test plan

- [ ] Merge and wait for the next dependabot or github-actions PR to open.
- [ ] Confirm CodeRabbit does not post an auto-review.
- [ ] Comment `@coderabbitai review` on that same PR.
- [ ] Confirm CodeRabbit responds and posts a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)