### PR TITLE
fix(build-tests): bump branch-pinned-master to flex-3.23-php-8.5 (openemr master needs PHP 8.3+)

### DIFF
--- a/.github/workflows/build-tests-live.yml
+++ b/.github/workflows/build-tests-live.yml
@@ -68,9 +68,12 @@ jobs:
           persist-credentials: false
 
       - name: Pre-pull base images
-        # All three current scenarios target the same flex tag. If a
-        # fixture overrides INTEGRATION_IMAGE, the runner will pull
-        # that on-demand at first `docker run` inside run-scenario.sh.
+        # Pre-pull the default flex tag used by scenarios that don't
+        # override INTEGRATION_IMAGE (tag-pinned-with-data,
+        # release-packageserve). branch-pinned-master overrides to the
+        # flex-3.23-php-8.5 image (openemr master now requires PHP 8.3+
+        # per openemr/openemr#13280), which the runner pulls on-demand
+        # at first `docker run` inside run-scenario.sh.
         run: |
           set -euo pipefail
           docker pull mariadb:10.6

--- a/tools/build-tests/fixtures/branch-pinned-master/inputs.env
+++ b/tools/build-tests/fixtures/branch-pinned-master/inputs.env
@@ -2,6 +2,14 @@
 # patient-portal/API globals, and random theme (funStuff=2 -> ThemeTwo).
 # Exercises: git clone --branch master, translationsDevelopment branch,
 # random theme branch, ppapi globals branch.
+#
+# Master requires PHP 8.3+ as of openemr/openemr#13280 (2026-07-30), so the
+# default flex-3.22-php-8.2 image the runner falls back to trips
+# Checker::checkPhpVersion() and demo_build.sh bails without creating the
+# database. Override to the flex-3.23-php-8.5 image, matching the
+# PHP_VERSION_ABBR=85 declared below and the canonical dev image in
+# openemr's CONTRIBUTING.md.
+INTEGRATION_IMAGE=openemr/openemr:flex-3.23-php-8.5
 DOCKERDEMO=two
 DOCKERMYSQLHOST=mysql
 PHP_VERSION_ABBR=85


### PR DESCRIPTION
## Summary

- Adds `INTEGRATION_IMAGE=openemr/openemr:flex-3.23-php-8.5` to `tools/build-tests/fixtures/branch-pinned-master/inputs.env` so the runner picks a PHP 8.3+ image.
- Refreshes the pre-pull comment in `.github/workflows/build-tests-live.yml` to note the scenarios no longer share a single flex tag.

## Why

openemr master now requires PHP 8.3+ as of [openemr/openemr#13280](https://github.com/openemr/openemr/pull/13280) (landed 2026-07-30). The `branch-pinned-master` scenario clones master and runs `demo_build.sh` against the flex image, but `run-scenario.sh` defaults to `flex-3.22-php-8.2` unless the fixture overrides. That trips `Checker::checkPhpVersion()` in `interface/globals.php` and `demo_build.sh` bails without creating the demo database — producing this failure in [run 30692408986](https://github.com/openemr/demo_farm_openemr/actions/runs/30692408986):

```
--- start openemr container + run demo_build.sh ---
--- wait for completion marker (timeout: 900s) ---
    ok: completion marker seen
--- mariadb state check ---
FAIL: expected database 'two' not found in mariadb
  databases present:
    | information_schema | mysql | performance_schema | sys
```

`tag-pinned-with-data` and `release-packageserve` are unaffected — they exercise released openemr versions against their shipped-PHP images.

## Why 8.5 specifically

The fixture already declares `PHP_VERSION_ABBR=85`, and `flex-3.23-php-8.5` is openemr's canonical dev image per its `CONTRIBUTING.md`. Aligning to the existing intent.

## Test plan

- [ ] Kick off the `build-tests (live integration)` workflow (schedule or `workflow_dispatch`) — `branch-pinned-master` should now succeed
- [ ] `tag-pinned-with-data` and `release-packageserve` continue to pull `flex-3.22-php-8.2` and pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)