### PR TITLE
fix(auto-derive): honor GH_TOKEN + apply auth to raw.githubusercontent.com fetches

### DIFF
--- a/tools/auto-derive/derive.sh
+++ b/tools/auto-derive/derive.sh
@@ -81,6 +81,27 @@ UPSTREAM_BASE="https://raw.githubusercontent.com/openemr/openemr"
 CURRENT_DIR=""
 MODE="dry-run"
 
+# Auth header args for curls that hit GitHub-owned hosts. Both
+# api.github.com and https://raw.githubusercontent.com honor the same
+# Bearer token; using it lifts the caller from the 60/hr anonymous quota
+# (shared across the CI runner IP pool -- lately runs dry on scheduled
+# fires and surfaced as HTTP 403 on api.github.com) to the 1000/hr
+# per-repository quota for the workflow-issued ${{ github.token }} (or
+# 15000/hr on GHEC). Prefer $GH_TOKEN (gh CLI convention, matches what
+# .github/workflows/derive-ip-map-*.yml sets); fall back to
+# $GITHUB_TOKEN (Actions-injected convention).
+#
+# Callers MUST only apply these args to curls whose destination is a
+# GitHub-owned host. fetch_upstream in particular gates on UPSTREAM_BASE
+# starting with https://raw.githubusercontent.com/ so that a user- or
+# workflow-configured non-GitHub upstream never receives the token.
+GITHUB_AUTH_ARGS=()
+_derive_github_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+if [[ -n "$_derive_github_token" ]]; then
+    GITHUB_AUTH_ARGS=(-H "Authorization: Bearer $_derive_github_token")
+fi
+unset _derive_github_token
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --current-dir)
@@ -158,7 +179,15 @@ fetch_upstream() {
         cp "$src" "$dest"
     else
         local url="$UPSTREAM_BASE/$ref/$path"
-        if ! curl -fsSL "$url" -o "$dest"; then
+        # UPSTREAM_BASE is --upstream-base configurable, so only send the
+        # workflow token to the exact HTTPS raw.githubusercontent.com host.
+        # A custom-configured or http:// upstream must NOT receive it (would
+        # exfil to an attacker-controlled host, or over cleartext).
+        local -a request_auth_args=()
+        if [[ "$UPSTREAM_BASE" == https://raw.githubusercontent.com/* ]]; then
+            request_auth_args=("${GITHUB_AUTH_ARGS[@]}")
+        fi
+        if ! curl -fsSL "${request_auth_args[@]}" "$url" -o "$dest"; then
             fail "failed to fetch $url"
         fi
     fi
@@ -401,12 +430,8 @@ list_upstream_dir() {
             fail "list_upstream_dir: cannot derive GitHub API URL from non-raw.githubusercontent.com UPSTREAM_BASE: $UPSTREAM_BASE"
         fi
         local api_url="https://api.github.com/repos/${owner_repo}/contents/${path}?ref=${ref}"
-        local auth_args=()
-        if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-            auth_args=(-H "Authorization: Bearer $GITHUB_TOKEN")
-        fi
         local body
-        if ! body="$(curl -fsSL "${auth_args[@]}" \
+        if ! body="$(curl -fsSL "${GITHUB_AUTH_ARGS[@]}" \
                         -H "Accept: application/vnd.github+json" \
                         "$api_url")"; then
             fail "failed to fetch directory listing from $api_url"


### PR DESCRIPTION
## Summary

- Widens `derive.sh`'s token check to accept both `GH_TOKEN` (gh CLI convention, what the workflows set) and `GITHUB_TOKEN` (Actions-injected convention), preferring the former.
- Extracts the auth-header args into a script-load-time global `GITHUB_AUTH_ARGS` and applies it to **both** curl call sites — not just `list_upstream_dir` (api.github.com) but also `fetch_upstream` (raw.githubusercontent.com), which had the same latent unauthenticated-rate-limit bug.

## Why

[Run 32226898295](https://github.com/openemr/demo_farm_openemr/actions/runs/32226898295) (the scheduled reconcile, 2026-08-19 07:14 UTC) failed:

```
ERROR: failed to fetch directory listing from
https://api.github.com/repos/openemr/openemr/contents/ci?ref=master
curl: (22) The requested URL returned error: 403
```

`.github/workflows/derive-ip-map-*.yml:69` sets `GH_TOKEN: ${{ github.token }}`, but `derive.sh:405` only checked `${GITHUB_TOKEN:-}`. Variable-name mismatch → `auth_args` empty → anonymous curl → subject to the shared CI-runner IP pool's 60/hr limit. Recent history shows this workflow has been passing on pull_request / schedule / repository_dispatch runs, which means it's been quietly making unauthenticated requests all along; today just happened to be the day the shared pool ran dry.

## Why also fix `fetch_upstream`

The other curl in `derive.sh` (line 161) hits `raw.githubusercontent.com` and had the same problem — no auth, subject to a separate but equally shared 60/hr anonymous quota. Since I was already touching the auth pattern, consolidating both curls onto one authenticated global costs nothing and prevents the next "silently-anonymous-until-it-hits-the-wall" surprise on the raw endpoint.

`raw.githubusercontent.com` honors the same `Authorization: Bearer <token>` header (lifts to the 5000/hr authenticated quota).

## Scope check

Grepped the rest of `tools/` for the same pattern — only these two call sites in `derive.sh` reference GitHub-owned hosts. No other latent tokens-not-honored bugs elsewhere.

## Test plan

- [x] `tools/auto-derive/fixtures-and-tests/test.sh` — all 8 fixtures pass (file:// fixture paths take the non-curl branch, so this validates the code refactor didn't break the offline path)
- [x] Shellcheck clean
- [ ] Post-merge: next scheduled reconcile fire should show authenticated curls and no 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)